### PR TITLE
v0.2 refinements: resolve the 14 open issues

### DIFF
--- a/.github/workflows/WP_6_6.yaml
+++ b/.github/workflows/WP_6_6.yaml
@@ -1,0 +1,72 @@
+name: WP 6.6 [PHP8.0-8.4] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions:  ['mysql:8.4', 'mariadb:10.11', 'mariadb:11.4']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: ${{ matrix.mysql-versions }}
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
+          --health-interval=10s
+          --health-timeout=10s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor
+          && rm -rf composer.lock
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.6.* --dev --no-update
+          && composer require roots/wordpress:6.6.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.6.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on WP6.6
+        env:
+          environment_github: true
+        run: composer all
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_PIXIE }}
+          files: ./clover.xml
+          fail_ci_if_error: false

--- a/.github/workflows/WP_6_7.yaml
+++ b/.github/workflows/WP_6_7.yaml
@@ -1,8 +1,8 @@
-name: GitHub_CI
+name: WP 6.7 [PHP8.0-8.4] Tests
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ master ]
   pull_request:
     branches: [ master, develop ]
 
@@ -11,8 +11,8 @@ jobs:
     strategy:
       matrix:
         operating-system: [ubuntu-latest]
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
-        mysql-versions: ['mysql:5.7', 'mariadb:10.7','mariadb:10.6','mariadb:10.5','mariadb:10.4','mariadb:10.3','mariadb:10.2']
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions:  ['mysql:8.4', 'mariadb:10.11', 'mariadb:11.4']
     runs-on: ${{ matrix.operating-system }}
     services:
       # Setup MYSQL
@@ -24,11 +24,11 @@ jobs:
         ports:
           - 3306:3306
         options: >-
-          --health-cmd="mysqladmin ping"
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
           --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-  
+          --health-timeout=10s
+          --health-retries=10
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -44,20 +44,29 @@ jobs:
         run: php -v
 
       - name: Clear existing composer
-        run: rm -rf wordpress && rm -rf vendor && rm -rf composer.lock 
-
+        run: >
+          sudo rm -rf vendor
+          && rm -rf composer.lock
       - name: Validate composer.json and composer.lock
         run: composer validate
 
       - name: Install dependencies
-        run: composer clearcache && rm -rf composer.lock && composer install --prefer-dist --no-suggest
+        run: >
+          rm -rf composer.lock
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.7.* --dev --no-update
+          && composer require roots/wordpress:6.7.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.7.* --dev --no-update
+          && composer update --no-cache
 
-      - name: Run Tests
+      - name: Run Tests on WP6.7
         env:
           environment_github: true
         run: composer all
 
-      - name: Codecov
-        run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CODECOV_PIXIE }}
-
-      
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_PIXIE }}
+          files: ./clover.xml
+          fail_ci_if_error: false

--- a/.github/workflows/WP_6_8.yaml
+++ b/.github/workflows/WP_6_8.yaml
@@ -1,0 +1,72 @@
+name: WP 6.8 [PHP8.0-8.4] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions:  ['mysql:8.4', 'mariadb:10.11', 'mariadb:11.4']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: ${{ matrix.mysql-versions }}
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
+          --health-interval=10s
+          --health-timeout=10s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor
+          && rm -rf composer.lock
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.8.* --dev --no-update
+          && composer require roots/wordpress:6.8.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.8.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on WP6.8
+        env:
+          environment_github: true
+        run: composer all
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_PIXIE }}
+          files: ./clover.xml
+          fail_ci_if_error: false

--- a/.github/workflows/WP_6_9.yaml
+++ b/.github/workflows/WP_6_9.yaml
@@ -1,0 +1,72 @@
+name: WP 6.9 [PHP8.0-8.4] Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master, develop ]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        mysql-versions:  ['mysql:8.4', 'mariadb:10.11', 'mariadb:11.4']
+    runs-on: ${{ matrix.operating-system }}
+    services:
+      # Setup MYSQL
+      mysql-service:
+        image: ${{ matrix.mysql-versions }}
+        env:
+          MYSQL_ROOT_PASSWORD: 'crab'
+          MYSQL_DATABASE: pc_core_tests
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect || mysqladmin ping -uroot -pcrab"
+          --health-interval=10s
+          --health-timeout=10s
+          --health-retries=10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, intl, pcov
+          ini-values: post_max_size=256M, log_errors=1
+          tools: pecl
+
+      - name: Check PHP Version
+        run: php -v
+
+      - name: Clear existing composer
+        run: >
+          sudo rm -rf vendor
+          && rm -rf composer.lock
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: >
+          rm -rf composer.lock
+          && composer clearcache
+          && composer require php-stubs/wordpress-stubs:6.9.* --dev --no-update
+          && composer require roots/wordpress:6.9.* --dev --no-update
+          && composer require wp-phpunit/wp-phpunit:6.9.* --dev --no-update
+          && composer update --no-cache
+
+      - name: Run Tests on WP6.9
+        env:
+          environment_github: true
+        run: composer all
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_PIXIE }}
+          files: ./clover.xml
+          fail_ci_if_error: false

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,57 +1,84 @@
+checks:
+    php:
+        code_rating: true
+        duplication: true
+        fix_php_opening_tag: false
+        remove_php_closing_tag: false
+        one_class_per_file: false
+        side_effects_or_types: false
+        no_mixed_inline_html: false
+        require_braces_around_control_structures: false
+        php5_style_constructor: false
+        no_global_keyword: false
+        avoid_usage_of_logical_operators: false
+        psr2_class_declaration: false
+        no_underscore_prefix_in_properties: false
+        no_underscore_prefix_in_methods: false
+        blank_line_after_namespace_declaration: false
+        single_namespace_per_use: false
+        psr2_switch_declaration: false
+        psr2_control_structure_declaration: false
+        avoid_superglobals: false
+        security_vulnerabilities: false
+        no_exit: false
+
+build:
+    dependencies:
+        override:
+            - 'composer install --no-interaction --prefer-dist'
+    nodes:
+        analysis:
+            project_setup:
+                override:
+                    - 'true'
+            tests:
+                override:
+                    - php-scrutinizer-run
+
+tools:
+    php_analyzer:
+        enabled: true
+        filter:
+            excluded_paths: ['tests/*', 'docs/*', 'wordpress/*', 'node_modules/*', 'vendor/*']
+        config:
+            checkstyle:
+                enabled: true
+                naming:
+                    isser_method_name: ^.*$
+                    utility_class_name: ^.*$
+            doc_comment_fixes:
+                enabled: false
+            reflection_fixes:
+                enabled: false
+            use_statement_fixes:
+                enabled: false
+            simplify_boolean_return:
+                enabled: true
+    php_changetracking: true
+    php_cpd: true
+    php_cs_fixer: false
+    php_mess_detector: true
+    php_pdepend: true
+    sensiolabs_security_checker: true
 
 filter:
     paths:
         - 'src/*'
-        - '/*'
     excluded_paths:
         - 'tests/*'
         - 'docs/*'
-tools:
-    php_mess_detector:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*']
-        config:
-            unused_code_rules: { unused_formal_parameter: true }
-            controversial_rules: { superglobals: false }
-            design_rules: { exit_expression: false }
-    php_analyzer:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*']
-        config:
-            parameter_reference_check: { enabled: true }
-            checkstyle: { enabled: true, no_trailing_whitespace: true, naming: { enabled: true, local_variable: '^[a-z][a-zA-Z0-9]*$', abstract_class_name: ^Abstract|Factory$, utility_class_name: 'Utils?$', constant_name: '^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$', property_name: '^[a-z][a-zA-Z0-9]*$', method_name: '^(?:[a-z]|__)[a-zA-Z0-9]*$', parameter_name: '^[a-z][a-zA-Z0-9]*$', interface_name: '^[A-Z][a-zA-Z0-9]*Interface$', type_name: '^[A-Z][a-zA-Z0-9]*$', exception_name: '^[A-Z][a-zA-Z0-9]*Exception$', isser_method_name: '^(?:is|has|should|may|supports)' } }
-            unreachable_code: { enabled: true }
-            check_access_control: { enabled: true }
-            typo_checks: { enabled: true }
-            check_variables: { enabled: true }
-            suspicious_code: { enabled: false, overriding_parameter: false, overriding_closure_use: false, parameter_closure_use_conflict: false, parameter_multiple_times: false, non_existent_class_in_instanceof_check: false, non_existent_class_in_catch_clause: false, assignment_of_null_return: false, non_commented_switch_fallthrough: false, non_commented_empty_catch_block: false, overriding_private_members: false, use_statement_alias_conflict: false, precedence_in_condition_assignment: false }
-            dead_assignments: { enabled: true }
-            verify_php_doc_comments: { enabled: true, parameters: true, return: true, suggest_more_specific_types: true, ask_for_return_if_not_inferrable: true, ask_for_param_type_annotation: true }
-            loops_must_use_braces: { enabled: false }
-            check_usage_context: { enabled: true, method_call_on_non_object: { enabled: true, ignore_null_pointer: true }, foreach: { value_as_reference: true, traversable: true }, missing_argument: true, argument_type_checks: lenient }
-            simplify_boolean_return: { enabled: false }
-            phpunit_checks: { enabled: false }
-            reflection_checks: { enabled: false }
-            precedence_checks: { enabled: true, assignment_in_condition: true, comparison_of_bit_result: true }
-            basic_semantic_checks: { enabled: true }
-            doc_comment_fixes: { enabled: false }
-            reflection_fixes: { enabled: false }
-            use_statement_fixes: { enabled: true, remove_unused: true, preserve_multiple: false, order_alphabetically: false }
-    php_code_sniffer:
-        command: 'phpcs -n -s -p -v'
-        filter:
-            excluded_paths: ['tests/*', 'docs/*']
-        config:
-            tab_width: '2'
-            standard: WordPress
-            sniffs: { psr1: { files: { side_effects_sniff: false } }, generic: { code_analysis: { for_loop_with_test_function_call_sniff: false, empty_statement_sniff: false, unnecessary_final_modifier_sniff: false, useless_overriding_method_sniff: false, jumbled_incrementer_sniff: false }, php: { deprecated_functions_sniff: false, character_before_php_opening_tag_sniff: false } }, squiz: { scope: { static_this_usage_sniff: false, method_scope_sniff: false, member_var_scope_sniff: false }, classes: { self_member_reference_sniff: false }, php: { non_executable_code_sniff: false } }, wordpress: { arrays: { array_declaration_sniff: true }, classes: { valid_class_name_sniff: true }, files: { file_name_sniff: true }, formatting: { multiple_statement_alignment_sniff: true }, functions: { function_call_signature_sniff: true, function_declaration_argument_spacing_sniff: true }, naming_conventions: { valid_function_name_sniff: true }, objects: { object_instantiation_sniff: true }, php: { discouraged_functions_sniff: true }, strings: { double_quote_usage_sniff: true }, white_space: { control_structure_spacing_sniff: true, operator_spacing_sniff: true, php_indent_sniff: true }, xss: { escape_output_sniff: true } } }
-    sensiolabs_security_checker:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*']
-    php_cpd:
-        filter:
-            excluded_paths: ['tests/*', 'docs/*']
-    php_pdepend:
-        excluded_dirs:
-            - tests
-            - docs
+        - 'wordpress/*'
+        - 'node_modules/*'
+        - 'vendor/*'
+
+coding_style:
+    php:
+        indentation:
+            general:
+                use_tabs: false
+                size: 4
+        spaces:
+            before_parentheses:
+                closure_definition: true
+            around_operators:
+                concatenation: true

--- a/README.md
+++ b/README.md
@@ -28,12 +28,38 @@ An expressive, query builder for WordPRess it can also be referred as a Database
 $thing = QB::table('someTable')->where('something','=', 'something else')->first();
 ```
 
+## New in v0.2
+
+The v0.2 refinements add the following, all backwards-compatible:
+
+* **Opt-in throw on WPDB error** — set `Connection::THROW_ON_ERROR` to have a `$wpdb` error raise a `Pixie\WpDbException` instead of failing silently.
+* **Table aliases** — alias a selection or join table with the array syntax `['table' => 'alias']`, e.g. `->table(['posts' => 'p'])` / `->join(['users' => 'u'], …)`.
+* **`when()`** — Eloquent-style conditional: `->when($condition, fn($q) => $q->where(…), fn($q) => …)`.
+* **JSON Support Phase 2** — verbose, portable JSON modification expressions via `$qb->jsonExpression()`: `set`, `insert`, `replace`, `appendArray`, `insertArray`, `remove`, `merge`, `mergePatch`, `mergePreserve`, plus `orderByJson($col, $nodes, $dir, $castType)`. Uses the verbose `JSON_*` function syntax (never `->`/`->>`) so it runs on MySQL 5.7+ and MariaDB 10.2+.
+
+```php
+// Throw on WPDB error (opt-in)
+$connection = new Connection($wpdb, [Connection::THROW_ON_ERROR => true]);
+
+// Aliased tables + conditional clause
+$qb->table(['posts' => 'p'])
+   ->join(['users' => 'u'], 'p.post_author', '=', 'u.ID')
+   ->when($onlyPublished, fn($q) => $q->where('p.post_status', '=', 'publish'))
+   ->get();
+
+// JSON modification (portable JSON_SET) in an update
+$qb->table('settings')->where('id', '=', 1)
+   ->update(['data' => $qb->jsonExpression()->set('data', ['profile', 'name'], 'Sam')]);
+```
+
+Internally the v0.2 work also relocated identifier sanitisation into a `Sanitizer` class, converted query statements and events to value objects, and uncoupled the where/table/select/join builders into self-contained handlers — all with no public API changes.
+
 # Install
 
 ## Perquisites
 
-* WordPress 5.7+ (tested upto 5.9)
-* PHP 7.1+ (includes support for PHP8)
+* WordPress 5.7+ (tested up to 6.9)
+* PHP 8.0+
 * MySql 5.7+ or MariaDB 10.2+
 * Composer (optional)
 
@@ -94,6 +120,7 @@ Values
 | use_wpdb_prefix   | Connection:: USE_WPDB_PREFIX        | BOOL | If true will use WPDB prefix and ignore custom prefix
 | clone_wpdb      | Connection:: CLONE_WPDB       | BOOL | If true, will clone WPDB to not use reference to the instance (usually the $GLOBAL)|
 | show_errors | Connection:: SHOW_ERRORS | BOOL | If set to true will configure WPDB to show/hide errors |
+| throw_on_error | Connection:: THROW_ON_ERROR | BOOL | If true, a `$wpdb` error during execution throws a `Pixie\WpDbException` instead of failing silently. Off by default. |
  
 
 ```php
@@ -155,6 +182,7 @@ A few features have been inspired by the [Pecee-pixie](https://github.com/skippe
 
 
 ## Changelog
+* 0.2.0 - v0.2 refinements: opt-in throw on WPDB error (`THROW_ON_ERROR`), table aliases via `['table' => 'alias']` for selection and joins, Eloquent-style `when()`, JSON Support Phase 2 (portable `JSON_*` modification expressions + `orderByJson` cast-to-type), sanitiser relocated to a `Sanitizer` class, statements & events as value objects, query builders uncoupled into self-contained condition handlers. Toolchain updated to WordPress 6.9, PHP floor 8.0, PHPUnit ^8||^9, PHPStan ^2. No breaking API changes.
 * 0.0.3 - More improvements to the `updateOrInsert()` method.
 * 0.0.2 - Improvements to the `updateOrInsert()` method
 * 0.0.1 - Various external and interal changes made to the initial code written by [Muhammad Usman](http://usman.it/)

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "gin0115/wpunit-helpers": "~1",
         "roave/security-advisories": "dev-latest",
         "friendsofphp/php-cs-fixer": "^3",
-        "phpmyadmin/sql-parser": "dev-master"
+        "phpmyadmin/sql-parser": "^5.8"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "license": "MIT",
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "authors": [{
             "name": "Glynn Quelch",
             "email": "glynn@pinkcrab.co.uk",
@@ -28,19 +29,20 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0",
+        "php": ">=8.0.0",
         "usmanhalalit/viocon": "1.0.*@dev"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0 || ^8.0",
-        "phpstan/phpstan": "^1.0",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "php-stubs/wordpress-stubs": "^5.9.0",
-        "roots/wordpress": "^5.9",
-        "wp-phpunit/wp-phpunit": "^5.9",
-        "symfony/var-dumper": "4.*",
-        "yoast/phpunit-polyfills": "^1.0.0",
-        "gin0115/wpunit-helpers": "~1.0.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
+        "phpstan/phpstan": "^2.0",
+        "szepeviktor/phpstan-wordpress": "^2.0",
+        "php-stubs/wordpress-stubs": "6.9.*",
+        "roots/wordpress": "6.9.*",
+        "wp-phpunit/wp-phpunit": "6.9.*",
+        "symfony/var-dumper": "*",
+        "yoast/phpunit-polyfills": "^1.0.0 || ^2.0.0",
+        "gin0115/wpunit-helpers": "~1",
+        "roave/security-advisories": "dev-latest",
         "friendsofphp/php-cs-fixer": "^3",
         "phpmyadmin/sql-parser": "dev-master"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,10 @@ includes:
     - vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
     level: 4
+    # WPDB hands back `mixed`; PHPDoc types on our own code are documentation,
+    # not runtime guarantees, so defensive is_string()/is_object() guards must
+    # stay. Don't treat PHPDoc types as certain when narrowing.
+    treatPhpDocTypesAsCertain: false
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - %currentWorkingDirectory%/src/

--- a/src/AliasFacade.php
+++ b/src/AliasFacade.php
@@ -8,7 +8,6 @@ use Pixie\QueryBuilder\QueryBuilderHandler;
  * This class gives the ability to access non-static methods statically
  *
  * Class AliasFacade
- *
  */
 class AliasFacade
 {
@@ -18,7 +17,7 @@ class AliasFacade
     protected static $queryBuilderInstance;
 
     /**
-     * @param string $method
+     * @param string  $method
      * @param mixed[] $args
      *
      * @return mixed

--- a/src/Binding.php
+++ b/src/Binding.php
@@ -8,11 +8,11 @@ use Pixie\QueryBuilder\Raw;
 class Binding
 {
     public const STRING = '%s';
-    public const BOOL = '%d';
-    public const INT = '%d';
-    public const FLOAT = '%f';
-    public const JSON = '%s';
-    public const RAW = ':RAW';
+    public const BOOL   = '%d';
+    public const INT    = '%d';
+    public const FLOAT  = '%f';
+    public const JSON   = '%s';
+    public const RAW    = ':RAW';
 
     /**
      * Holds the value to bind with
@@ -36,14 +36,14 @@ class Binding
     protected $isRaw = false;
 
     /**
-     * @param mixed $value
+     * @param mixed       $value
      * @param string|null $type
      */
     public function __construct($value, ?string $type = null)
     {
         $this->verifyType($type);
         $this->value = $value;
-        $this->type = $type;
+        $this->type  = $type;
         if (self::RAW === $type) {
             $this->isRaw = true;
         }
@@ -52,7 +52,8 @@ class Binding
     /**
      * Creates a binding for a String
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return self
      */
     public static function asString($value): self
@@ -63,7 +64,8 @@ class Binding
     /**
      * Creates a binding for a Float
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return self
      */
     public static function asFloat($value): self
@@ -74,7 +76,8 @@ class Binding
     /**
      * Creates a binding for a Int
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return self
      */
     public static function asInt($value): self
@@ -85,7 +88,8 @@ class Binding
     /**
      * Creates a binding for a Bool
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return self
      */
     public static function asBool($value): self
@@ -96,7 +100,8 @@ class Binding
     /**
      * Creates a binding for a JSON
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return self
      */
     public static function asJSON($value): self
@@ -107,7 +112,8 @@ class Binding
     /**
      * Creates a binding for a Raw
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return self
      */
     public static function asRaw($value): self
@@ -118,9 +124,11 @@ class Binding
     /**
      * Verifies that the passed type is allowed
      *
-     * @param string|null $type
+     * @param  string|null $type
+     *
      * @return void
-     * @throws Exception if not a valid type.
+     *
+     * @throws Exception if not a valid type
      */
     protected function verifyType(?string $type): void
     {
@@ -147,7 +155,7 @@ class Binding
      */
     public function getValue()
     {
-        return ! $this->hasTypeDefined()
+        return !$this->hasTypeDefined()
             ? new Raw($this->value)
             : $this->value;
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -2,20 +2,25 @@
 
 namespace Pixie;
 
-use wpdb;
 use Exception;
-use Viocon\Container;
 use Pixie\AliasFacade;
 use Pixie\EventHandler;
 use Pixie\QueryBuilder\QueryBuilderHandler;
+use Viocon\Container;
+use wpdb;
+
+use function mb_strlen;
 
 class Connection
 {
-    /** Config keys */
+    /**
+     * Config keys
+     */
     public const CLONE_WPDB        = 'clone_wpdb';
     public const PREFIX            = 'prefix';
     public const SHOW_ERRORS       = 'show_errors';
     public const USE_WPDB_PREFIX   = 'use_wpdb_prefix';
+    public const THROW_ON_ERROR    = 'throw_on_error';
 
     /**
      * @var Container
@@ -49,15 +54,15 @@ class Connection
 
     /**
      * @param wpdb                 $wpdb
-     * @param array<string, mixed>  $adapterConfig
-     * @param string|null           $alias
-     * @param Container|null        $container
+     * @param array<string, mixed> $adapterConfig
+     * @param string|null          $alias
+     * @param Container|null       $container
      */
     public function __construct(
         wpdb $wpdb,
         array $adapterConfig = [],
         ?string $alias = null,
-        ?Container $container = null
+        ?Container $container = null,
     ) {
         $this->setAdapterConfig($adapterConfig);
         $this->dbInstance = $this->configureWpdb($wpdb);
@@ -78,23 +83,22 @@ class Connection
     /**
      * Configures the instance of WPDB based on adaptor config values.
      *
-     * @param \wpdb $wpdb
-     * @return \wpdb
+     * @param  wpdb $wpdb
+     *
+     * @return wpdb
      */
     protected function configureWpdb(wpdb $wpdb): wpdb
     {
         // Maybe clone instance.
-        if (
-            array_key_exists(self::CLONE_WPDB, $this->adapterConfig)
+        if (array_key_exists(self::CLONE_WPDB, $this->adapterConfig)
             && true === $this->adapterConfig[self::CLONE_WPDB]
         ) {
             $wpdb = clone $wpdb;
         }
 
         // Maybe set the prefix to WPDB's.
-        if (
-            array_key_exists(self::USE_WPDB_PREFIX, $this->adapterConfig)
-            && 0 < \mb_strlen($this->adapterConfig[self::USE_WPDB_PREFIX])
+        if (array_key_exists(self::USE_WPDB_PREFIX, $this->adapterConfig)
+            && 0 < mb_strlen($this->adapterConfig[self::USE_WPDB_PREFIX])
         ) {
             $this->adapterConfig[self::PREFIX] = $wpdb->prefix;
         }

--- a/src/Event.php
+++ b/src/Event.php
@@ -17,23 +17,132 @@ declare(strict_types=1);
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * @author Glynn Quelch <glynn@pinkcrab.co.uk>
+ * @author  Glynn Quelch <glynn@pinkcrab.co.uk>
  * @license http://www.opensource.org/licenses/mit-license.html  MIT License
- * @package Gin0115\Pixie WPDB
- * @since 0.0.1
+ *
+ * @since   0.0.1
  */
 
 namespace Pixie;
 
+use Closure;
+
 class Event
 {
-    /** Events */
+    /**
+     * Events
+     */
     public const BEFORE_SELECT = 'before-select';
-    public const AFTER_SELECT = 'after-select';
+    public const AFTER_SELECT  = 'after-select';
     public const BEFORE_INSERT = 'before-insert';
-    public const AFTER_INSERT = 'after-insert';
+    public const AFTER_INSERT  = 'after-insert';
     public const BEFORE_UPDATE = 'before-update';
-    public const AFTER_UPDATE = 'after-update';
+    public const AFTER_UPDATE  = 'after-update';
     public const BEFORE_DELETE = 'before-delete';
-    public const AFTER_DELETE = 'after-delete';
+    public const AFTER_DELETE  = 'after-delete';
+
+    /**
+     * Sentinel table that matches any table.
+     */
+    public const ANY_TABLE = ':any';
+
+    /**
+     * The event name, e.g. Event::BEFORE_SELECT.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * The table the event is bound to, or ':any'.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The handler invoked when the event fires.
+     *
+     * @var Closure
+     */
+    protected $action;
+
+    /**
+     * @param string      $name   the event name
+     * @param string|null $table  the table to bind to (null/':any' for any table)
+     * @param Closure     $action the handler to run
+     */
+    public function __construct(string $name, ?string $table, Closure $action)
+    {
+        $this->name   = $name;
+        $this->table  = $table ?? self::ANY_TABLE;
+        $this->action = $action;
+    }
+
+    /**
+     * Lazy static constructor for an event of any name.
+     *
+     * @param string      $name
+     * @param string|null $table
+     * @param Closure     $action
+     */
+    public static function on(string $name, ?string $table, Closure $action): self
+    {
+        return new self($name, $table, $action);
+    }
+
+    public static function beforeSelect(?string $table, Closure $action): self
+    {
+        return new self(self::BEFORE_SELECT, $table, $action);
+    }
+
+    public static function afterSelect(?string $table, Closure $action): self
+    {
+        return new self(self::AFTER_SELECT, $table, $action);
+    }
+
+    public static function beforeInsert(?string $table, Closure $action): self
+    {
+        return new self(self::BEFORE_INSERT, $table, $action);
+    }
+
+    public static function afterInsert(?string $table, Closure $action): self
+    {
+        return new self(self::AFTER_INSERT, $table, $action);
+    }
+
+    public static function beforeUpdate(?string $table, Closure $action): self
+    {
+        return new self(self::BEFORE_UPDATE, $table, $action);
+    }
+
+    public static function afterUpdate(?string $table, Closure $action): self
+    {
+        return new self(self::AFTER_UPDATE, $table, $action);
+    }
+
+    public static function beforeDelete(?string $table, Closure $action): self
+    {
+        return new self(self::BEFORE_DELETE, $table, $action);
+    }
+
+    public static function afterDelete(?string $table, Closure $action): self
+    {
+        return new self(self::AFTER_DELETE, $table, $action);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getTable(): string
+    {
+        return $this->table;
+    }
+
+    public function getAction(): Closure
+    {
+        return $this->action;
+    }
 }

--- a/src/EventHandler.php
+++ b/src/EventHandler.php
@@ -9,7 +9,9 @@ use Pixie\QueryBuilder\Raw;
 class EventHandler
 {
     /**
-     * @var array<string, array<string, Closure>>
+     * Registered events as Event objects, keyed by table then event name (#50).
+     *
+     * @var array<string, array<string, Event>>
      */
     protected $events = [];
 
@@ -19,15 +21,37 @@ class EventHandler
     protected $firedEvents = [];
 
     /**
+     * Returns the registered event handlers as closures, keyed by table then
+     * event name. Kept in this (closure leaf) shape for backwards compatibility.
+     *
      * @return array<string, array<string, Closure>>
      */
     public function getEvents()
+    {
+        $events = [];
+        foreach ($this->events as $table => $tableEvents) {
+            // Preserve table keys even when empty (e.g. after removeEvent()).
+            $events[$table] = [];
+            foreach ($tableEvents as $name => $event) {
+                $events[$table][$name] = $event->getAction();
+            }
+        }
+
+        return $events;
+    }
+
+    /**
+     * Returns the registered Event objects, keyed by table then event name.
+     *
+     * @return array<string, array<string, Event>>
+     */
+    public function getRegisteredEvents(): array
     {
         return $this->events;
     }
 
     /**
-     * @param string $event
+     * @param string     $event
      * @param string|Raw $table
      *
      * @return Closure|null
@@ -38,26 +62,38 @@ class EventHandler
             return null;
         }
 
-        return $this->events[$table][$event] ?? null;
+        $registered = $this->events[$table][$event] ?? null;
+
+        return $registered instanceof Event ? $registered->getAction() : null;
     }
 
     /**
-     * @param string $event
+     * Register an event from an Event object (#50).
+     *
+     * @param Event $event
+     *
+     * @return void
+     */
+    public function register(Event $event): void
+    {
+        $this->events[$event->getTable()][$event->getName()] = $event;
+    }
+
+    /**
+     * @param string      $event
      * @param string|null $table
-     * @param Closure $action
+     * @param Closure     $action
      *
      * @return void
      */
     public function registerEvent(string $event, ?string $table, Closure $action)
     {
-        $table = $table ?? ':any';
-
-        $this->events[$table][$event] = $action;
+        $this->register(new Event($event, $table, $action));
     }
 
     /**
      * @param string $event
-     * @param string  $table
+     * @param string $table
      *
      * @return void
      */
@@ -68,7 +104,7 @@ class EventHandler
 
     /**
      * @param QueryBuilderHandler $queryBuilder
-     * @param string $event
+     * @param string              $event
      *
      * @return mixed
      */

--- a/src/Hydration/Hydrator.php
+++ b/src/Hydration/Hydrator.php
@@ -11,19 +11,19 @@ namespace Pixie\Hydration;
 use Exception;
 use stdClass;
 use Throwable;
+
 use function is_object;
 use function method_exists;
 use function trim;
 use function ucfirst;
 
 /**
- * @template T
+ * @template T of object
  */
 class Hydrator
 {
     /**
      * The model to hydrate
-
      *
      * @var class-string<T>
      */
@@ -37,8 +37,8 @@ class Hydrator
     protected $constructorArgs;
 
     /**
-
-     * @param class-string<T> $model
+     *
+     * @param class-string<T>          $model
      * @param array<string|int, mixed> $constructorArgs
      */
     public function __construct(string $model = stdClass::class, array $constructorArgs = [])
@@ -113,7 +113,6 @@ class Hydrator
 
     /**
      * Construct an instance of the model
-
      *
      * @return T
      */
@@ -121,7 +120,9 @@ class Hydrator
     {
         $class = $this->model;
         try {
-            /** @var T */
+            /**
+             * @var T
+             */
             $instance = empty($this->constructorArgs)
                 ? new $class()
                 : new $class(...$this->constructorArgs);
@@ -135,9 +136,9 @@ class Hydrator
     /**
      * Sets a property to the current model
      *
-     * @param T $model
+     * @param T      $model
      * @param string $property
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return T
      */
@@ -187,7 +188,7 @@ class Hydrator
      * Generates a generic setter method using either underscore [set_property()] or PSR2 style [setProperty()]
      *
      * @param string $property
-     * @param bool $underscore
+     * @param bool   $underscore
      *
      * @return string
      */

--- a/src/JSON/JsonExpressionFactory.php
+++ b/src/JSON/JsonExpressionFactory.php
@@ -2,16 +2,21 @@
 
 namespace Pixie\JSON;
 
-use Pixie\Exception;
 use Pixie\Connection;
+use Pixie\Exception;
 use Pixie\QueryBuilder\Raw;
 use Pixie\QueryBuilder\TablePrefixer;
+
+use function implode;
+use function json_encode;
 
 class JsonExpressionFactory
 {
     use TablePrefixer;
 
-    /** @var Connection */
+    /**
+     * @var Connection
+     */
     protected $connection;
 
     public function __construct(Connection $connection)
@@ -22,7 +27,7 @@ class JsonExpressionFactory
     /**
      * Returns the current connection instance.
      *
-     * @return connection
+     * @return Connection
      */
     public function getConnection(): Connection
     {
@@ -32,7 +37,8 @@ class JsonExpressionFactory
     /**
      * Normalises the values passed as nodes
      *
-     * @param mixed $nodes
+     * @param  mixed $nodes
+     *
      * @return string
      */
     protected function normaliseNodes($nodes): string
@@ -43,22 +49,26 @@ class JsonExpressionFactory
         }
 
         // Remove all none string.
-        $nodes = array_filter($nodes, function ($node): bool {
-            return is_string($node);
-        });
+        $nodes = array_filter(
+            $nodes,
+            function ($node): bool {
+                return is_string($node);
+            }
+        );
 
         // If we have no nodes, throw.
-        if (count($nodes) === 0) {
-            throw new Exception("Only strings values may be passed as nodes.");
+        if (0 === count($nodes)) {
+            throw new Exception('Only strings values may be passed as nodes.');
         }
 
-        return \implode('.', $nodes);
+        return implode('.', $nodes);
     }
 
     /**
-     * @param string          $column  The database column which holds the JSON value
-     * @param string|string[] $nodes   The json key/index to search
-     * @return \Pixie\QueryBuilder\Raw
+     * @param  string          $column The database column which holds the JSON value
+     * @param  string|string[] $nodes  The json key/index to search
+     *
+     * @return Raw
      */
     public function extractAndUnquote(string $column, $nodes): Raw
     {
@@ -69,5 +79,243 @@ class JsonExpressionFactory
         $column = $this->addTablePrefix($column, true);
 
         return new Raw("JSON_UNQUOTE(JSON_EXTRACT({$column}, \"$.{$nodes}\"))");
+    }
+
+    /* -----------------------------------------------------------------------
+     * JSON Support Phase 2 (#28) — modification expressions.
+     *
+     * Each method returns a Raw expression using the portable verbose JSON_*
+     * function syntax (never ->/->>), suitable for the lowest DB WordPress
+     * supports (MySQL 5.7+ / MariaDB 10.2+). The returned Raw composes into
+     * update()/insert()/select()/orderBy() like any other expression.
+     * --------------------------------------------------------------------- */
+
+    /**
+     * JSON_SET — insert or update the value at the given path.
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param mixed           $value
+     */
+    public function set(string $column, $nodes, $value): Raw
+    {
+        return $this->modify('JSON_SET', $column, $nodes, $value);
+    }
+
+    /**
+     * JSON_INSERT — insert the value only if the path does not already exist.
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param mixed           $value
+     */
+    public function insert(string $column, $nodes, $value): Raw
+    {
+        return $this->modify('JSON_INSERT', $column, $nodes, $value);
+    }
+
+    /**
+     * JSON_REPLACE — update the value only if the path already exists.
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param mixed           $value
+     */
+    public function replace(string $column, $nodes, $value): Raw
+    {
+        return $this->modify('JSON_REPLACE', $column, $nodes, $value);
+    }
+
+    /**
+     * JSON_ARRAY_APPEND — append a value to the array at the given path.
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param mixed           $value
+     */
+    public function appendArray(string $column, $nodes, $value): Raw
+    {
+        return $this->modify('JSON_ARRAY_APPEND', $column, $nodes, $value);
+    }
+
+    /**
+     * JSON_ARRAY_INSERT — insert a value at a specific array index.
+     *
+     * The nodes must include the target index, e.g. ['data', 'list[1]'].
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param mixed           $value
+     */
+    public function insertArray(string $column, $nodes, $value): Raw
+    {
+        return $this->modify('JSON_ARRAY_INSERT', $column, $nodes, $value);
+    }
+
+    /**
+     * JSON_REMOVE — remove the value at the given path.
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     */
+    public function remove(string $column, $nodes): Raw
+    {
+        $path   = $this->normaliseNodes($nodes);
+        $column = $this->addTablePrefix($column, true);
+
+        return new Raw(sprintf('JSON_REMOVE(%s, "$.%s")', $column, $path));
+    }
+
+    /**
+     * JSON_MERGE_PRESERVE — merge a document, preserving duplicate keys as arrays.
+     *
+     * @param string $column
+     * @param mixed  $document array/object/JSON-string document to merge in
+     */
+    public function mergePreserve(string $column, $document): Raw
+    {
+        return $this->merge($column, $document);
+    }
+
+    /**
+     * Alias of mergePreserve(); JSON_MERGE is deprecated in favour of it.
+     *
+     * @param string $column
+     * @param mixed  $document
+     */
+    public function merge(string $column, $document): Raw
+    {
+        $column = $this->addTablePrefix($column, true);
+
+        return new Raw(
+            sprintf(
+                'JSON_MERGE_PRESERVE(%s, %s)',
+                $column,
+                $this->formatJsonDocument($document)
+            )
+        );
+    }
+
+    /**
+     * JSON_MERGE_PATCH — RFC 7396 merge (last value wins, nulls remove keys).
+     *
+     * @param string $column
+     * @param mixed  $document
+     */
+    public function mergePatch(string $column, $document): Raw
+    {
+        $column = $this->addTablePrefix($column, true);
+
+        return new Raw(
+            sprintf(
+                'JSON_MERGE_PATCH(%s, %s)',
+                $column,
+                $this->formatJsonDocument($document)
+            )
+        );
+    }
+
+    /**
+     * Extract a JSON value cast to a SQL type, for use in orderBy and the like.
+     *
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param string          $type   A SQL type, e.g. 'UNSIGNED', 'DECIMAL(10,2)', 'CHAR'.
+     */
+    public function orderByCast(string $column, $nodes, string $type): Raw
+    {
+        $path   = $this->normaliseNodes($nodes);
+        $column = $this->addTablePrefix($column, true);
+
+        return new Raw(
+            sprintf(
+                'CAST(JSON_UNQUOTE(JSON_EXTRACT(%s, "$.%s")) AS %s)',
+                $column,
+                $path,
+                $type
+            )
+        );
+    }
+
+    /**
+     * Shared builder for the path-and-value modification functions.
+     *
+     * @param string          $function
+     * @param string          $column
+     * @param string|string[] $nodes
+     * @param mixed           $value
+     */
+    protected function modify(string $function, string $column, $nodes, $value): Raw
+    {
+        $path   = $this->normaliseNodes($nodes);
+        $column = $this->addTablePrefix($column, true);
+
+        return new Raw(
+            sprintf(
+                '%s(%s, "$.%s", %s)',
+                $function,
+                $column,
+                $path,
+                $this->formatValue($value)
+            )
+        );
+    }
+
+    /**
+     * Formats a scalar/array value for inlining into a JSON modification call.
+     *
+     * @param mixed $value
+     */
+    protected function formatValue($value): string
+    {
+        if ($value instanceof Raw) {
+            return (string) $value;
+        }
+
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        if (is_null($value)) {
+            return 'NULL';
+        }
+
+        if (is_array($value) || is_object($value)) {
+            return $this->formatJsonDocument($value);
+        }
+
+        return sprintf("'%s'", $this->escapeString((string) $value));
+    }
+
+    /**
+     * Formats an array/object/JSON-string into a JSON document expression.
+     *
+     * Uses JSON_EXTRACT('<json>', '$') to parse the string literal into a JSON
+     * value. This is portable across both MySQL 5.7+ and MariaDB 10.2+, whereas
+     * CAST(... AS JSON) is rejected by MariaDB.
+     *
+     * @param mixed $document
+     */
+    protected function formatJsonDocument($document): string
+    {
+        if ($document instanceof Raw) {
+            return (string) $document;
+        }
+
+        $json = is_string($document) ? $document : (string) json_encode($document);
+
+        return sprintf("JSON_EXTRACT('%s', '$')", $this->escapeString($json));
+    }
+
+    /**
+     * Escapes single quotes for safe inlining as a SQL string literal.
+     */
+    protected function escapeString(string $value): string
+    {
+        return str_replace("'", "''", $value);
     }
 }

--- a/src/JSON/JsonHandler.php
+++ b/src/JSON/JsonHandler.php
@@ -6,19 +6,25 @@ use Pixie\Connection;
 
 class JsonHandler
 {
-    /** @var Connection */
+    /**
+     * @var Connection
+     */
     protected $connection;
 
-    /** @var JsonSelectorHandler */
+    /**
+     * @var JsonSelectorHandler
+     */
     protected $jsonSelectorHandler;
 
-    /** @var JsonExpressionFactory */
+    /**
+     * @var JsonExpressionFactory
+     */
     protected $jsonExpressionFactory;
 
     public function __construct(Connection $connection)
     {
-        $this->connection = $connection;
-        $this->jsonSelectorHandler = new JsonSelectorHandler($connection);
+        $this->connection            = $connection;
+        $this->jsonSelectorHandler   = new JsonSelectorHandler($connection);
         $this->jsonExpressionFactory = new JsonExpressionFactory($connection);
     }
 
@@ -45,12 +51,14 @@ class JsonHandler
     /**
      * Parses a JSON selector and returns as an Extract and Unquote expression.
      *
-     * @param string $selector
+     * @param  string $selector
+     *
      * @return string
      */
     public function extractAndUnquoteFromJsonSelector(string $selector): string
     {
         $selector = $this->jsonSelectorHandler()->toJsonSelector($selector);
+
         return $this->jsonExpressionFactory()->extractAndUnquote(
             $selector->getColumn(),
             $selector->getNodes()
@@ -60,7 +68,8 @@ class JsonHandler
     /**
      * Checks if the passed values is a valid JSON Selector
      *
-     * @param mixed $expression
+     * @param  mixed $expression
+     *
      * @return bool
      */
     public function isJsonSelector($expression): bool

--- a/src/JSON/JsonSelector.php
+++ b/src/JSON/JsonSelector.php
@@ -19,13 +19,13 @@ class JsonSelector
     protected $nodes;
 
     /**
-     * @param string $column
+     * @param string   $column
      * @param string[] $nodes
      */
     public function __construct(string $column, array $nodes)
     {
         $this->column = $column;
-        $this->nodes = $nodes;
+        $this->nodes  = $nodes;
     }
 
     /**

--- a/src/JSON/JsonSelectorHandler.php
+++ b/src/JSON/JsonSelectorHandler.php
@@ -2,8 +2,8 @@
 
 namespace Pixie\JSON;
 
-use Pixie\Exception;
 use Pixie\Connection;
+use Pixie\Exception;
 use Pixie\HasConnection;
 use Pixie\QueryBuilder\TablePrefixer;
 
@@ -11,7 +11,9 @@ class JsonSelectorHandler implements HasConnection
 {
     use TablePrefixer;
 
-    /** @var Connection */
+    /**
+     * @var Connection
+     */
     protected $connection;
 
     public function __construct(Connection $connection)
@@ -22,7 +24,7 @@ class JsonSelectorHandler implements HasConnection
     /**
      * Returns the current connection instance.
      *
-     * @return connection
+     * @return Connection
      */
     public function getConnection(): Connection
     {
@@ -33,22 +35,25 @@ class JsonSelectorHandler implements HasConnection
      * Checks if the passed expression is for JSON
      * this->denotes->json
      *
-     * @param string $expression
+     * @param  string $expression
+     *
      * @return bool
      */
     public function isJsonSelector($expression): bool
     {
         return is_string($expression)
-        && 2 <= count(array_diff(explode('->', $expression), array("")));
+        && 2 <= count(array_diff(explode('->', $expression), ['']));
     }
 
     /**
-    * Gets the column name form a potential array
-    *
-    * @param string $expression
-    * @return string
-    * @throws Exception If invalid JSON Selector string passed.
-    */
+     * Gets the column name form a potential array
+     *
+     * @param  string $expression
+     *
+     * @return string
+     *
+     * @throws Exception if invalid JSON Selector string passed
+     */
     public function getColumn(string $expression): string
     {
         return $this->toJsonSelector($expression)->getColumn();
@@ -57,9 +62,11 @@ class JsonSelectorHandler implements HasConnection
     /**
      * Gets all JSON object keys while removing the column name.
      *
-     * @param string $expression
+     * @param  string $expression
+     *
      * @return string[]
-     * @throws Exception If invalid JSON Selector string passed.
+     *
+     * @throws Exception if invalid JSON Selector string passed
      */
     public function getNodes(string $expression): array
     {
@@ -69,22 +76,30 @@ class JsonSelectorHandler implements HasConnection
     /**
      * Casts a valid JSON selector to a JsonSelector object.
      *
-     * @param string $expression
+     * @param  string $expression
+     *
      * @return JsonSelector
-     * @throws Exception If invalid JSON Selector string passed.
+     *
+     * @throws Exception if invalid JSON Selector string passed
      */
     public function toJsonSelector(string $expression): JsonSelector
     {
-        if (! $this->isJsonSelector($expression)) {
+        if (!$this->isJsonSelector($expression)) {
             throw new Exception('JSON expression must contain at least 2 values, the table column and at least 1 node.', 1);
         }
 
-        /** @var string[] Check done above. */
-        $parts = array_diff(explode('->', $expression), array(""));
+        /**
+         * @var string[] check done above
+         */
+        $parts = array_diff(explode('->', $expression), ['']);
 
-        /** @var string */
+        /**
+         * @var string
+         */
         $column = array_shift($parts);
-        /** @var string[] */
+        /**
+         * @var string[]
+         */
         $nodes = $parts;
 
         return new JsonSelector($column, $nodes);

--- a/src/QueryBuilder/Handler/JoinConditionHandler.php
+++ b/src/QueryBuilder/Handler/JoinConditionHandler.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Self-contained handler for building JOIN clauses (#31).
+ *
+ * Owns the rendering of the `joins` statements — including aliased join tables
+ * (['table' => 'alias'] and the legacy ['table', 'alias']) and the ON criteria
+ * — reusing the adapter's low-level primitives.
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Handler;
+
+use Pixie\QueryBuilder\Raw;
+use Pixie\QueryBuilder\WPDBAdapter;
+
+class JoinConditionHandler
+{
+    /**
+     * @var WPDBAdapter
+     */
+    protected $adapter;
+
+    public function __construct(WPDBAdapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Builds the JOIN portion of a query from its statements.
+     *
+     * @param array<string|Closure, mixed|mixed[]> $statements
+     */
+    public function build(array $statements): string
+    {
+        $sql = '';
+
+        if (!array_key_exists('joins', $statements) || !is_array($statements['joins'])) {
+            return $sql;
+        }
+
+        foreach ($statements['joins'] as $joinArr) {
+            $table       = $this->resolveTable($joinArr['table']);
+            $joinBuilder = $joinArr['joinBuilder'];
+
+            /**
+             * @var string[]
+             */
+            $sqlArr = [
+                $sql,
+                strtoupper($joinArr['type']),
+                'JOIN',
+                $table,
+                'ON',
+                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
+            ];
+
+            $sql = $this->adapter->concatenateQuery($sqlArr);
+        }
+
+        return $sql;
+    }
+
+    /**
+     * Resolves a join table (string, Raw, or aliased array) to SQL.
+     *
+     * @param mixed $table
+     */
+    protected function resolveTable($table): string
+    {
+        if (is_array($table)) {
+            // Supports both ['table', 'alias'] (indexed) and the
+            // ['table' => 'alias'] (associative) syntax used for selection.
+            $joinKeys = array_keys($table);
+            if (is_string($joinKeys[0])) {
+                $realTable = $joinKeys[0];
+                $alias     = $table[$realTable];
+            } else {
+                $realTable = $table[0];
+                $alias     = $table[1];
+            }
+
+            $mainTable  = $this->adapter->stringifyValue($this->adapter->wrapSanitizer($realTable));
+            $aliasTable = $this->adapter->stringifyValue($this->adapter->wrapSanitizer($alias));
+
+            return $mainTable . ' AS ' . $aliasTable;
+        }
+
+        return $table instanceof Raw
+            ? $this->adapter->parseRaw($table)
+            : (string) $this->adapter->stringifyValue($this->adapter->wrapSanitizer($table));
+    }
+}

--- a/src/QueryBuilder/Handler/SelectConditionHandler.php
+++ b/src/QueryBuilder/Handler/SelectConditionHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Self-contained handler for building the SELECT field list (#31).
+ *
+ * Owns the rendering of the `selects` statement (including ['field' => 'alias']
+ * aliasing) into a SQL fragment, reusing the adapter's low-level primitives.
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Handler;
+
+use Pixie\QueryBuilder\WPDBAdapter;
+
+class SelectConditionHandler
+{
+    /**
+     * @var WPDBAdapter
+     */
+    protected $adapter;
+
+    public function __construct(WPDBAdapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Builds the comma-separated field list for a SELECT clause.
+     *
+     * @param array<int|string, string> $selects
+     */
+    public function build(array $selects): string
+    {
+        return $this->adapter->arrayStr($selects, ', ');
+    }
+}

--- a/src/QueryBuilder/Handler/TableConditionHandler.php
+++ b/src/QueryBuilder/Handler/TableConditionHandler.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Self-contained handler for building the FROM table list (#31).
+ *
+ * Owns the rendering of the `tables` statement (including ['table' => 'alias']
+ * aliasing) into a SQL fragment, reusing the adapter's low-level primitives.
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Handler;
+
+use Pixie\QueryBuilder\WPDBAdapter;
+
+class TableConditionHandler
+{
+    /**
+     * @var WPDBAdapter
+     */
+    protected $adapter;
+
+    public function __construct(WPDBAdapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Builds the comma-separated table list for a FROM clause.
+     *
+     * @param array<int|string, string> $tables
+     */
+    public function build(array $tables): string
+    {
+        return $this->adapter->arrayStr($tables, ', ');
+    }
+}

--- a/src/QueryBuilder/Handler/WhereConditionHandler.php
+++ b/src/QueryBuilder/Handler/WhereConditionHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Self-contained handler for building WHERE/HAVING criteria fragments (#31).
+ *
+ * Owns the type-prefixing and whitespace normalisation around the generic
+ * criteria builder, reusing the adapter's buildCriteria() primitive.
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Handler;
+
+use Pixie\QueryBuilder\WPDBAdapter;
+
+class WhereConditionHandler
+{
+    /**
+     * @var WPDBAdapter
+     */
+    protected $adapter;
+
+    public function __construct(WPDBAdapter $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Builds a criteria fragment of a given type (e.g. WHERE / HAVING).
+     *
+     * @param array<string|Closure, mixed|mixed[]> $statements
+     * @param string                               $key        the statement key to read (wheres / havings)
+     * @param string                               $type       the SQL keyword to prefix (WHERE / HAVING)
+     * @param bool                                 $bindValues
+     *
+     * @return array{0:string, 1:string[]}
+     */
+    public function build(array $statements, string $key, string $type, bool $bindValues = true): array
+    {
+        $criteria = '';
+        $bindings = [];
+
+        if (isset($statements[$key])) {
+            list($criteria, $bindings) = $this->adapter->buildCriteria($statements[$key], $bindValues);
+
+            if ($criteria) {
+                $criteria = $type . ' ' . $criteria;
+            }
+        }
+
+        // Remove any multiple whitespace.
+        $criteria = (string) preg_replace('!\s+!', ' ', $criteria);
+
+        return [$criteria, $bindings];
+    }
+}

--- a/src/QueryBuilder/JoinBuilder.php
+++ b/src/QueryBuilder/JoinBuilder.php
@@ -2,12 +2,14 @@
 
 namespace Pixie\QueryBuilder;
 
+use Pixie\QueryBuilder\Statement\CriteriaStatement;
+
 class JoinBuilder extends QueryBuilderHandler
 {
     /**
-     * @param string|Raw $key
+     * @param string|Raw  $key
      * @param string|null $operator
-     * @param mixed $value
+     * @param mixed       $value
      *
      * @return static
      */
@@ -17,9 +19,9 @@ class JoinBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw  $key
      * @param string|null $operator
-     * @param mixed $value
+     * @param mixed       $value
      *
      * @return static
      */
@@ -29,9 +31,9 @@ class JoinBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw  $key
      * @param string|null $operator
-     * @param mixed $value
+     * @param mixed       $value
      *
      * @return static
      */
@@ -39,7 +41,7 @@ class JoinBuilder extends QueryBuilderHandler
     {
         $key                            = $this->addTablePrefix($key);
         $value                          = $this->addTablePrefix($value);
-        $this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
+        $this->statements['criteria'][] = new CriteriaStatement($key, $operator, $value, $joiner);
 
         return $this;
     }

--- a/src/QueryBuilder/JsonQueryBuilder.php
+++ b/src/QueryBuilder/JsonQueryBuilder.php
@@ -2,15 +2,31 @@
 
 namespace Pixie\QueryBuilder;
 
+use Pixie\JSON\JsonExpressionFactory;
+
+use function implode;
+
 class JsonQueryBuilder extends QueryBuilderHandler
 {
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * Access the JSON expression factory for composing JSON modification
+     * expressions (JSON_SET, JSON_INSERT, JSON_MERGE_*, etc.) — Phase 2 (#28).
+     *
+     * Example: $qb->table('t')->update(['data' => $qb->jsonExpression()->set('data', ['a','b'], 1)]);
+     */
+    public function jsonExpression(): JsonExpressionFactory
+    {
+        return $this->jsonHandler->jsonExpressionFactory();
+    }
+
+    /**
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function whereJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -23,10 +39,11 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $column The database column which holds the JSON value
-     * @param string|Raw|string[] $nodes The json key/index to search
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
      * @return static
      */
     public function whereNotJson($column, $nodes, $operator = null, $value = null): self
@@ -41,12 +58,13 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function orWhereJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -59,12 +77,13 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function orWhereNotJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -77,54 +96,58 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param mixed[] $values
-    * @return static
-    */
+     * @param  string|Raw          $column The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes  The json key/index to search
+     * @param  mixed[]             $values
+     *
+     * @return static
+     */
     public function whereInJson($column, $nodes, $values): self
     {
         return $this->whereJsonHandler($column, $nodes, 'IN', $values, 'AND');
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param mixed[] $values
-    * @return static
-    */
+     * @param  string|Raw          $column The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes  The json key/index to search
+     * @param  mixed[]             $values
+     *
+     * @return static
+     */
     public function whereNotInJson($column, $nodes, $values): self
     {
         return $this->whereJsonHandler($column, $nodes, 'NOT IN', $values, 'AND');
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param mixed[] $values
-    * @return static
-    */
+     * @param  string|Raw          $column The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes  The json key/index to search
+     * @param  mixed[]             $values
+     *
+     * @return static
+     */
     public function orWhereInJson($column, $nodes, $values): self
     {
         return $this->whereJsonHandler($column, $nodes, 'IN', $values, 'OR');
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param mixed[] $values
-    * @return static
-    */
+     * @param  string|Raw          $column The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes  The json key/index to search
+     * @param  mixed[]             $values
+     *
+     * @return static
+     */
     public function orWhereNotInJson($column, $nodes, $values): self
     {
         return $this->whereJsonHandler($column, $nodes, 'NOT IN', $values, 'OR');
     }
 
     /**
-     * @param string|Raw $column
-    * @param string|Raw|string[] $nodes The json key/index to search
-     * @param mixed $valueFrom
-     * @param mixed $valueTo
+     * @param string|Raw          $column
+     * @param string|Raw|string[] $nodes     The json key/index to search
+     * @param mixed               $valueFrom
+     * @param mixed               $valueTo
      *
      * @return static
      */
@@ -134,10 +157,10 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $column
-    * @param string|Raw|string[] $nodes The json key/index to search
-     * @param mixed $valueFrom
-     * @param mixed $valueTo
+     * @param string|Raw          $column
+     * @param string|Raw|string[] $nodes     The json key/index to search
+     * @param mixed               $valueFrom
+     * @param mixed               $valueTo
      *
      * @return static
      */
@@ -147,12 +170,13 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function whereDayJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -160,16 +184,18 @@ class JsonQueryBuilder extends QueryBuilderHandler
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallJsonHandler($column, $nodes, 'DAY', $operator, $value);
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function whereMonthJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -177,16 +203,18 @@ class JsonQueryBuilder extends QueryBuilderHandler
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallJsonHandler($column, $nodes, 'MONTH', $operator, $value);
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function whereYearJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -194,16 +222,18 @@ class JsonQueryBuilder extends QueryBuilderHandler
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallJsonHandler($column, $nodes, 'YEAR', $operator, $value);
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
+     * @return static
+     */
     public function whereDateJson($column, $nodes, $operator = null, $value = null): self
     {
         // If two params are given then assume operator is =
@@ -211,17 +241,19 @@ class JsonQueryBuilder extends QueryBuilderHandler
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallJsonHandler($column, $nodes, 'DATE', $operator, $value);
     }
 
     /**
      * Maps a function call for a JSON where condition
      *
-     * @param string|Raw $column
-     * @param string|Raw|string[] $nodes
-     * @param string $function
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw          $column
+     * @param  string|Raw|string[] $nodes
+     * @param  string              $function
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     *
      * @return static
      */
     protected function whereFunctionCallJsonHandler($column, $nodes, $function, $operator, $value): self
@@ -243,13 +275,14 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-    * @param string|Raw $column The database column which holds the JSON value
-    * @param string|Raw|string[] $nodes The json key/index to search
-    * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-    * @param mixed|null $value
-    * @param string $joiner
-    * @return static
-    */
+     * @param  string|Raw          $column   The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes    The json key/index to search
+     * @param  string|mixed|null   $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null          $value
+     * @param  string              $joiner
+     *
+     * @return static
+     */
     protected function whereJsonHandler($column, $nodes, $operator = null, $value = null, string $joiner = 'AND'): self
     {
         // Handle potential raw values.
@@ -269,13 +302,13 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $table
-     * @param string|Raw $leftColumn
-     * @param string|Raw|string[]|null $leftNodes The json key/index to search
-     * @param string $operator
-     * @param string|Raw $rightColumn
+     * @param string|Raw               $table
+     * @param string|Raw               $leftColumn
+     * @param string|Raw|string[]|null $leftNodes   The json key/index to search
+     * @param string                   $operator
+     * @param string|Raw               $rightColumn
      * @param string|Raw|string[]|null $rightNodes
-     * @param string $type
+     * @param string                   $type
      *
      * @return static
      */
@@ -286,7 +319,7 @@ class JsonQueryBuilder extends QueryBuilderHandler
         string $operator,
         $rightColumn,
         $rightNodes,
-        $type = 'inner'
+        $type = 'inner',
     ): self {
         // Convert key if json
         if (null !== $rightNodes) {
@@ -302,11 +335,11 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $table
-     * @param string|Raw $leftColumn
-     * @param string|Raw|string[]|null $leftNodes The json key/index to search
-     * @param string $operator
-     * @param string|Raw $rightColumn
+     * @param string|Raw               $table
+     * @param string|Raw               $leftColumn
+     * @param string|Raw|string[]|null $leftNodes   The json key/index to search
+     * @param string                   $operator
+     * @param string|Raw               $rightColumn
      * @param string|Raw|string[]|null $rightNodes
      *
      * @return static
@@ -317,7 +350,7 @@ class JsonQueryBuilder extends QueryBuilderHandler
         $leftNodes,
         string $operator,
         $rightColumn,
-        $rightNodes
+        $rightNodes,
     ): self {
         return $this->joinJson(
             $table,
@@ -331,11 +364,11 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $table
-     * @param string|Raw $leftColumn
-     * @param string|Raw|string[]|null $leftNodes The json key/index to search
-     * @param string $operator
-     * @param string|Raw $rightColumn
+     * @param string|Raw               $table
+     * @param string|Raw               $leftColumn
+     * @param string|Raw|string[]|null $leftNodes   The json key/index to search
+     * @param string                   $operator
+     * @param string|Raw               $rightColumn
      * @param string|Raw|string[]|null $rightNodes
      *
      * @return static
@@ -346,7 +379,7 @@ class JsonQueryBuilder extends QueryBuilderHandler
         $leftNodes,
         string $operator,
         $rightColumn,
-        $rightNodes
+        $rightNodes,
     ): self {
         return $this->joinJson(
             $table,
@@ -360,11 +393,11 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $table
-     * @param string|Raw $leftColumn
-     * @param string|Raw|string[]|null $leftNodes The json key/index to search
-     * @param string $operator
-     * @param string|Raw $rightColumn
+     * @param string|Raw               $table
+     * @param string|Raw               $leftColumn
+     * @param string|Raw|string[]|null $leftNodes   The json key/index to search
+     * @param string                   $operator
+     * @param string|Raw               $rightColumn
      * @param string|Raw|string[]|null $rightNodes
      *
      * @return static
@@ -375,7 +408,7 @@ class JsonQueryBuilder extends QueryBuilderHandler
         $leftNodes,
         string $operator,
         $rightColumn,
-        $rightNodes
+        $rightNodes,
     ): self {
         return $this->joinJson(
             $table,
@@ -389,11 +422,11 @@ class JsonQueryBuilder extends QueryBuilderHandler
     }
 
     /**
-     * @param string|Raw $table
-     * @param string|Raw $leftColumn
-     * @param string|Raw|string[]|null $leftNodes The json key/index to search
-     * @param string $operator
-     * @param string|Raw $rightColumn
+     * @param string|Raw               $table
+     * @param string|Raw               $leftColumn
+     * @param string|Raw|string[]|null $leftNodes   The json key/index to search
+     * @param string                   $operator
+     * @param string|Raw               $rightColumn
      * @param string|Raw|string[]|null $rightNodes
      *
      * @return static
@@ -404,7 +437,7 @@ class JsonQueryBuilder extends QueryBuilderHandler
         $leftNodes,
         string $operator,
         $rightColumn,
-        $rightNodes
+        $rightNodes,
     ): self {
         return $this->joinJson(
             $table,
@@ -417,14 +450,13 @@ class JsonQueryBuilder extends QueryBuilderHandler
         );
     }
 
-
-
     // JSON
 
     /**
-     * @param string|Raw $column The database column which holds the JSON value
-     * @param string|Raw|string[] $nodes The json key/index to search
-     * @param string|null $alias The alias used to define the value in results, if not defined will use json_{$nodes}
+     * @param  string|Raw          $column The database column which holds the JSON value
+     * @param  string|Raw|string[] $nodes  The json key/index to search
+     * @param  string|null         $alias  The alias used to define the value in results, if not defined will use json_{$nodes}
+     *
      * @return static
      */
     public function selectJson($column, $nodes, ?string $alias = null): self
@@ -439,13 +471,14 @@ class JsonQueryBuilder extends QueryBuilderHandler
 
         // If deeply nested jsonKey.
         if (is_array($nodes)) {
-            $nodes = \implode('.', $nodes);
+            $nodes = implode('.', $nodes);
         }
 
         // Add any possible prefixes to the key
         $column = $this->addTablePrefix($column, true);
 
         $alias = null === $alias ? "json_{$nodes}" : $alias;
-        return  $this->select(new Raw("JSON_UNQUOTE(JSON_EXTRACT({$column}, \"$.{$nodes}\")) as {$alias}"));
+
+        return $this->select(new Raw("JSON_UNQUOTE(JSON_EXTRACT({$column}, \"$.{$nodes}\")) as {$alias}"));
     }
 }

--- a/src/QueryBuilder/NestedCriteria.php
+++ b/src/QueryBuilder/NestedCriteria.php
@@ -2,20 +2,22 @@
 
 namespace Pixie\QueryBuilder;
 
+use Pixie\QueryBuilder\Statement\CriteriaStatement;
+
 class NestedCriteria extends QueryBuilderHandler
 {
     /**
-     * @param string|Raw $key
+     * @param string|Raw        $key
      * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
-     * @param string $joiner
+     * @param mixed|null        $value
+     * @param string            $joiner
      *
      * @return $this
      */
     protected function whereHandler($key, $operator = null, $value = null, $joiner = 'AND')
     {
         $key                            = $this->addTablePrefix($key);
-        $this->statements['criteria'][] = compact('key', 'operator', 'value', 'joiner');
+        $this->statements['criteria'][] = new CriteriaStatement($key, $operator, $value, $joiner);
 
         return $this;
     }

--- a/src/QueryBuilder/QueryBuilderHandler.php
+++ b/src/QueryBuilder/QueryBuilderHandler.php
@@ -2,30 +2,33 @@
 
 namespace Pixie\QueryBuilder;
 
-use wpdb;
 use Closure;
-use Throwable;
 use Pixie\Binding;
-use Pixie\Exception;
 use Pixie\Connection;
-
+use Pixie\Exception;
 use Pixie\HasConnection;
-
-use Pixie\JSON\JsonHandler;
-use Pixie\QueryBuilder\Raw;
 use Pixie\Hydration\Hydrator;
+use Pixie\JSON\JsonHandler;
 use Pixie\JSON\JsonSelectorHandler;
 use Pixie\QueryBuilder\JoinBuilder;
 use Pixie\QueryBuilder\QueryObject;
+use Pixie\QueryBuilder\Raw;
+use Pixie\QueryBuilder\Statement\CriteriaStatement;
+use Pixie\QueryBuilder\Statement\JoinStatement;
+use Pixie\QueryBuilder\Statement\OrderByStatement;
+use Pixie\QueryBuilder\TablePrefixer;
 use Pixie\QueryBuilder\Transaction;
 use Pixie\QueryBuilder\WPDBAdapter;
-use Pixie\QueryBuilder\TablePrefixer;
+use Pixie\WpDbException;
+use Throwable;
+use wpdb;
+
 use function mb_strlen;
 
 class QueryBuilderHandler implements HasConnection
 {
     /**
-     * @method add
+     * Provides addTablePrefix() and related table-prefixing helpers.
      */
     use TablePrefixer;
 
@@ -52,12 +55,12 @@ class QueryBuilderHandler implements HasConnection
     /**
      * @var string|string[]|null
      */
-    protected $sqlStatement = null;
+    protected $sqlStatement;
 
     /**
      * @var string|null
      */
-    protected $tablePrefix = null;
+    protected $tablePrefix;
 
     /**
      * @var WPDBAdapter
@@ -87,16 +90,24 @@ class QueryBuilderHandler implements HasConnection
     protected $jsonHandler;
 
     /**
-     * @param \Pixie\Connection|null $connection
-     * @param string $fetchMode
-     * @param mixed[] $hydratorConstructorArgs
+     * When true, a WPDB error after execution throws a WpDbException
+     * instead of failing silently. Opt-in, defaults to false for BC.
+     *
+     * @var bool
+     */
+    protected $throwOnError = false;
+
+    /**
+     * @param Connection|null $connection
+     * @param string                 $fetchMode
+     * @param mixed[]                $hydratorConstructorArgs
      *
      * @throws Exception if no connection passed and not previously established
      */
     final public function __construct(
-        Connection $connection = null,
+        ?Connection $connection = null,
         string $fetchMode = \OBJECT,
-        ?array $hydratorConstructorArgs = null
+        ?array $hydratorConstructorArgs = null,
     ) {
         if (is_null($connection)) {
             // throws if connection not already established.
@@ -135,16 +146,42 @@ class QueryBuilderHandler implements HasConnection
         if (isset($adapterConfig[Connection::PREFIX])) {
             $this->tablePrefix = $adapterConfig[Connection::PREFIX];
         }
+
+        if (isset($adapterConfig[Connection::THROW_ON_ERROR])) {
+            $this->throwOnError = (bool) $adapterConfig[Connection::THROW_ON_ERROR];
+        }
+    }
+
+    /**
+     * Throws a WpDbException if WPDB reported an error during the last
+     * execution and the connection opted in via Connection::THROW_ON_ERROR.
+     *
+     * @param string|null $sql the statement that was executed, for context
+     *
+     * @return void
+     *
+     * @throws WpDbException
+     */
+    protected function handleQueryError(?string $sql = null): void
+    {
+        if (false === $this->throwOnError) {
+            return;
+        }
+
+        if ('' !== $this->dbInstance()->last_error) {
+            throw WpDbException::fromWpdb($this->dbInstance(), $sql);
+        }
     }
 
     /**
      * Fetch query results as object of specified type
      *
-     * @param string $className
-     * @param array<int, mixed> $constructorArgs
+     * @param  string            $className
+     * @param  array<int, mixed> $constructorArgs
+     *
      * @return static
      */
-    public function asObject($className, $constructorArgs = array()): self
+    public function asObject($className, $constructorArgs = []): self
     {
         return $this->setFetchMode($className, $constructorArgs);
     }
@@ -152,7 +189,7 @@ class QueryBuilderHandler implements HasConnection
     /**
      * Set the fetch mode
      *
-     * @param string $mode
+     * @param string                 $mode
      * @param array<int, mixed>|null $constructorArgs
      *
      * @return static
@@ -172,7 +209,7 @@ class QueryBuilderHandler implements HasConnection
      *
      * @throws Exception
      */
-    public function newQuery(Connection $connection = null): self
+    public function newQuery(?Connection $connection = null): self
     {
         if (is_null($connection)) {
             $connection = $this->connection;
@@ -187,7 +224,7 @@ class QueryBuilderHandler implements HasConnection
     /**
      * Returns a new instance of the current, with the passed connection.
      *
-     * @param \Pixie\Connection $connection
+     * @param Connection $connection
      *
      * @return static
      */
@@ -199,8 +236,9 @@ class QueryBuilderHandler implements HasConnection
     /**
      * Interpolates a query
      *
-     * @param string $query
-     * @param array<mixed> $bindings
+     * @param  string       $query
+     * @param  array<mixed> $bindings
+     *
      * @return string
      */
     public function interpolateQuery(string $query, array $bindings = []): string
@@ -232,10 +270,6 @@ class QueryBuilderHandler implements HasConnection
         $start        = microtime(true);
         $sqlStatement = empty($bindings) ? $sql : $this->interpolateQuery($sql, $bindings);
 
-        if (!is_string($sqlStatement)) {
-            throw new Exception('Could not interpolate query', 1);
-        }
-
         return [$sqlStatement, microtime(true) - $start];
     }
 
@@ -264,13 +298,15 @@ class QueryBuilderHandler implements HasConnection
             $executionTime      = $statement[1];
         }
 
-        $start  = microtime(true);
-        $result = $this->dbInstance()->get_results(
-            is_array($this->sqlStatement) ? (end($this->sqlStatement) ?: '') : $this->sqlStatement,
+        $executedSql = is_array($this->sqlStatement) ? (end($this->sqlStatement) ?: '') : $this->sqlStatement;
+        $start       = microtime(true);
+        $result      = $this->dbInstance()->get_results(
+            $executedSql,
             // If we are using the hydrator, return as OBJECT and let the hydrator map the correct model.
-            $this->useHydrator() ? OBJECT : $this->getFetchMode()
+            $this->useHydrator() ? OBJECT : $this->getFetchMode() // @phpstan-ignore-line
         );
         $executionTime += microtime(true) - $start;
+        $this->handleQueryError(is_string($executedSql) ? $executedSql : null);
         $this->sqlStatement = null;
 
         // Ensure we have an array of results.
@@ -331,7 +367,7 @@ class QueryBuilderHandler implements HasConnection
      * Shortcut of ->where('key','=','value')->get();
      *
      * @param string $fieldName
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return array<mixed,mixed>|null Can return any object using hydrator
      */
@@ -344,7 +380,7 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string $fieldName
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return \stdClass\array<mixed,mixed>|object|null Can return any object using hydrator
      */
@@ -357,9 +393,10 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string $fieldName
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return \stdClass\array<mixed,mixed>|object Can return any object using hydrator
+     *
      * @throws Exception If fails to find
      */
     public function findOrFail($value, $fieldName = 'id')
@@ -368,6 +405,7 @@ class QueryBuilderHandler implements HasConnection
         if (null === $result) {
             throw new Exception("Failed to find {$fieldName}={$value}", 1);
         }
+
         return $result;
     }
 
@@ -376,7 +414,7 @@ class QueryBuilderHandler implements HasConnection
      *
      * @see Taken from the pecee-pixie library - https://github.com/skipperbent/pecee-pixie/
      *
-     * @param string $type
+     * @param string     $type
      * @param string|Raw $field
      *
      * @return float
@@ -397,7 +435,6 @@ class QueryBuilderHandler implements HasConnection
         if ('*' !== $field && true === isset($this->statements['selects']) && false === \in_array($field, $this->statements['selects'], true)) {
             throw new \Exception(sprintf('Failed %s query - the column %s hasn\'t been selected in the query.', $type, $field));
         }
-
 
         if (false === isset($this->statements['tables'])) {
             throw new Exception('No table selected');
@@ -492,7 +529,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string $type
+     * @param string                   $type
      * @param bool|array<mixed, mixed> $dataToBePassed
      *
      * @return mixed
@@ -516,7 +553,7 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param QueryBuilderHandler $queryBuilder
-     * @param string|null $alias
+     * @param string|null         $alias
      *
      * @return Raw
      */
@@ -534,7 +571,7 @@ class QueryBuilderHandler implements HasConnection
      * Handles the various insert operations based on the type.
      *
      * @param array<int|string, mixed|mixed[]> $data
-     * @param string $type
+     * @param string                           $type
      *
      * @return int|int[]|mixed|null can return a single row id, array of row ids, null (for failed) or any other value short circuited from event
      */
@@ -551,6 +588,7 @@ class QueryBuilderHandler implements HasConnection
 
             list($preparedQuery, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
             $this->dbInstance->get_results($preparedQuery);
+            $this->handleQueryError(is_string($preparedQuery) ? $preparedQuery : null);
 
             // Check we have a result.
             $return = 1 === $this->dbInstance->rows_affected ? $this->dbInstance->insert_id : null;
@@ -563,6 +601,7 @@ class QueryBuilderHandler implements HasConnection
 
                 list($preparedQuery, $time) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
                 $this->dbInstance->get_results($preparedQuery);
+                $this->handleQueryError(is_string($preparedQuery) ? $preparedQuery : null);
                 $executionTime += $time;
 
                 if (1 === $this->dbInstance->rows_affected) {
@@ -611,7 +650,7 @@ class QueryBuilderHandler implements HasConnection
     /**
      * @param array<string, mixed> $data
      *
-     * @return int|null Number of row effected, null for none.
+     * @return int|null number of row effected, null for none
      */
     public function update(array $data): ?int
     {
@@ -620,9 +659,10 @@ class QueryBuilderHandler implements HasConnection
             return $eventResult;
         }
         $queryObject                         = $this->getQuery('update', $data);
-        $r = $this->statement($queryObject->getSql(), $queryObject->getBindings());
+        $r                                   = $this->statement($queryObject->getSql(), $queryObject->getBindings());
         list($preparedQuery, $executionTime) = $r;
         $this->dbInstance()->get_results($preparedQuery);
+        $this->handleQueryError(is_string($preparedQuery) ? $preparedQuery : null);
         $this->fireEvents('after-update', $queryObject, $executionTime);
 
         return 0 !== (int) $this->dbInstance()->rows_affected
@@ -685,6 +725,7 @@ class QueryBuilderHandler implements HasConnection
 
         list($preparedQuery, $executionTime) = $this->statement($queryObject->getSql(), $queryObject->getBindings());
         $this->dbInstance()->get_results($preparedQuery);
+        $this->handleQueryError(is_string($preparedQuery) ? $preparedQuery : null);
         $this->fireEvents('after-delete', $queryObject, $executionTime);
 
         return $this->dbInstance()->rows_affected;
@@ -701,10 +742,38 @@ class QueryBuilderHandler implements HasConnection
     {
         $instance =  $this->constructCurrentBuilderClass($this->connection);
         $this->setFetchMode($this->getFetchMode(), $this->hydratorConstructorArgs);
+        $tables = $this->normalizeAliasedTables($tables);
         $tables = $this->addTablePrefix($tables, false);
         $instance->addStatement('tables', $tables);
 
         return $instance;
+    }
+
+    /**
+     * Expands any table arguments supplied as a ['table' => 'alias'] array into
+     * the flat table map used internally, so a table can be aliased the same way
+     * a select field is. Scalar/Raw/Closure tables are passed through untouched.
+     *
+     * @param array<int|string, mixed> $tables
+     *
+     * @return array<int|string, mixed>
+     */
+    protected function normalizeAliasedTables(array $tables): array
+    {
+        $normalized = [];
+        foreach ($tables as $key => $table) {
+            // A ['table' => 'alias'] map passed as a single variadic argument.
+            if (is_int($key) && is_array($table)) {
+                foreach ($table as $realTable => $alias) {
+                    $normalized[$realTable] = $alias;
+                }
+                continue;
+            }
+
+            $normalized[$key] = $table;
+        }
+
+        return $normalized;
     }
 
     /**
@@ -714,10 +783,38 @@ class QueryBuilderHandler implements HasConnection
      */
     public function from(...$tables): self
     {
+        $tables = $this->normalizeAliasedTables($tables);
         $tables = $this->addTablePrefix($tables, false);
         $this->addStatement('tables', $tables);
 
         return $this;
+    }
+
+    /**
+     * Conditionally apply modifications to the query (Eloquent-style).
+     *
+     * When $conditional is truthy the $true closure is invoked with this query
+     * builder; otherwise the optional $false closure is invoked. Whatever the
+     * invoked closure returns is passed back (so it can return its own value),
+     * falling back to this builder instance for fluent chaining.
+     *
+     * @param bool         $conditional whether to apply the $true branch
+     * @param Closure      $true        Applied when $conditional is true. Receives $this.
+     * @param Closure|null $false       Applied when $conditional is false. Receives $this.
+     *
+     * @return static|mixed
+     */
+    public function when(bool $conditional, Closure $true, ?Closure $false = null)
+    {
+        if ($conditional) {
+            $result = $true($this);
+        } elseif (null !== $false) {
+            $result = $false($this);
+        } else {
+            return $this;
+        }
+
+        return $result ?? $this;
     }
 
     /**
@@ -739,11 +836,11 @@ class QueryBuilderHandler implements HasConnection
 
             // If no alias passed, but field is for JSON. thrown an exception.
             if (is_numeric($field) && is_string($alias) && $this->jsonHandler->isJsonSelector($alias)) {
-                throw new Exception("An alias must be used if you wish to select from JSON Object", 1);
+                throw new Exception('An alias must be used if you wish to select from JSON Object', 1);
             }
 
             // Treat each array as a single table, to retain order added
-            $field = is_numeric($field)
+            $field       = is_numeric($field)
                 ? $field = $alias // If single colum
                 : $field = [$field => $alias]; // Has alias
 
@@ -782,7 +879,7 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string|array<string|int, mixed> $fields
-     * @param string          $defaultDirection
+     * @param string                          $defaultDirection
      *
      * @return static
      */
@@ -807,21 +904,29 @@ class QueryBuilderHandler implements HasConnection
             if (!$field instanceof Raw) {
                 $field = $this->addTablePrefix($field);
             }
-            $this->statements['orderBys'][] = compact('field', 'type');
+            $this->statements['orderBys'][] = new OrderByStatement($field, $type);
         }
 
         return $this;
     }
 
     /**
-     * @param string|Raw $key The database column which holds the JSON value
-     * @param string|Raw|string[] $jsonKey The json key/index to search
-     * @param string $defaultDirection
+     * @param  string|Raw          $key              The database column which holds the JSON value
+     * @param  string|Raw|string[] $jsonKey          The json key/index to search
+     * @param  string              $defaultDirection
+     * @param  string|null         $cast             Optional SQL type to CAST the extracted value to (#28),
+     *                                               e.g. 'UNSIGNED' or 'DECIMAL(10,2)'. Null = no cast
+     *                                               (BC).
+     *
      * @return static
      */
-    public function orderByJson($key, $jsonKey, string $defaultDirection = 'ASC'): self
+    public function orderByJson($key, $jsonKey, string $defaultDirection = 'ASC', ?string $cast = null): self
     {
-        $key = $this->jsonHandler->jsonExpressionFactory()->extractAndUnquote($key, $jsonKey);
+        $factory = $this->jsonHandler->jsonExpressionFactory();
+        $key     = null !== $cast
+            ? $factory->orderByCast($key, $jsonKey, $cast)
+            : $factory->extractAndUnquote($key, $jsonKey);
+
         return $this->orderBy($key, $defaultDirection);
     }
 
@@ -850,25 +955,25 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|string[]|Raw|Raw[]       $key
-     * @param string $operator
-     * @param mixed $value
-     * @param string $joiner
+     * @param string|string[]|Raw|Raw[] $key
+     * @param string                    $operator
+     * @param mixed                     $value
+     * @param string                    $joiner
      *
      * @return static
      */
     public function having($key, string $operator, $value, string $joiner = 'AND')
     {
         $key                           = $this->addTablePrefix($key);
-        $this->statements['havings'][] = compact('key', 'operator', 'value', 'joiner');
+        $this->statements['havings'][] = new CriteriaStatement($key, $operator, $value, $joiner);
 
         return $this;
     }
 
     /**
-     * @param string|string[]|Raw|Raw[]       $key
-     * @param string $operator
-     * @param mixed $value
+     * @param string|string[]|Raw|Raw[] $key
+     * @param string                    $operator
+     * @param mixed                     $value
      *
      * @return static
      */
@@ -878,9 +983,9 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw        $key
      * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param mixed|null        $value
      *
      * @return static
      */
@@ -896,9 +1001,9 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw|\Closure(QueryBuilderHandler):void $key
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param string|Raw|Closure(QueryBuilderHandler):void $key
+     * @param string|mixed|null                             $operator Can be used as value, if 3rd arg not passed
+     * @param mixed|null                                    $value
      *
      * @return static
      */
@@ -914,9 +1019,9 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw        $key
      * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param mixed|null        $value
      *
      * @return static
      */
@@ -932,9 +1037,9 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw        $key
      * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param mixed|null        $value
      *
      * @return static
      */
@@ -950,7 +1055,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw         $key
      * @param mixed[]|string|Raw $values
      *
      * @return static
@@ -961,7 +1066,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw         $key
      * @param mixed[]|string|Raw $values
      *
      * @return static
@@ -972,7 +1077,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw         $key
      * @param mixed[]|string|Raw $values
      *
      * @return static
@@ -983,7 +1088,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $key
+     * @param string|Raw         $key
      * @param mixed[]|string|Raw $values
      *
      * @return static
@@ -995,8 +1100,8 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string|Raw $key
-     * @param mixed $valueFrom
-     * @param mixed $valueTo
+     * @param mixed      $valueFrom
+     * @param mixed      $valueTo
      *
      * @return static
      */
@@ -1007,8 +1112,8 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string|Raw $key
-     * @param mixed $valueFrom
-     * @param mixed $valueTo
+     * @param mixed      $valueFrom
+     * @param mixed      $valueTo
      *
      * @return static
      */
@@ -1020,22 +1125,25 @@ class QueryBuilderHandler implements HasConnection
     /**
      * Handles all function call based where conditions
      *
-     * @param string|Raw $key
-     * @param string $function
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw        $key
+     * @param  string            $function
+     * @param  string|mixed|null $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null        $value
+     *
      * @return static
      */
     protected function whereFunctionCallHandler($key, $function, $operator, $value): self
     {
         $key = \sprintf('%s(%s)', $function, $this->addTablePrefix($key));
+
         return $this->where($key, $operator, $value);
     }
 
     /**
-     * @param string|Raw $key
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw        $key
+     * @param  string|mixed|null $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null        $value
+     *
      * @return self
      */
     public function whereMonth($key, $operator = null, $value = null): self
@@ -1045,13 +1153,15 @@ class QueryBuilderHandler implements HasConnection
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallHandler($key, 'MONTH', $operator, $value);
     }
 
     /**
-     * @param string|Raw $key
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw        $key
+     * @param  string|mixed|null $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null        $value
+     *
      * @return self
      */
     public function whereDay($key, $operator = null, $value = null): self
@@ -1061,13 +1171,15 @@ class QueryBuilderHandler implements HasConnection
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallHandler($key, 'DAY', $operator, $value);
     }
 
     /**
-     * @param string|Raw $key
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw        $key
+     * @param  string|mixed|null $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null        $value
+     *
      * @return self
      */
     public function whereYear($key, $operator = null, $value = null): self
@@ -1077,13 +1189,15 @@ class QueryBuilderHandler implements HasConnection
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallHandler($key, 'YEAR', $operator, $value);
     }
 
     /**
-     * @param string|Raw $key
-     * @param string|mixed|null $operator Can be used as value, if 3rd arg not passed
-     * @param mixed|null $value
+     * @param  string|Raw        $key
+     * @param  string|mixed|null $operator Can be used as value, if 3rd arg not passed
+     * @param  mixed|null        $value
+     *
      * @return self
      */
     public function whereDate($key, $operator = null, $value = null): self
@@ -1093,6 +1207,7 @@ class QueryBuilderHandler implements HasConnection
             $value    = $operator;
             $operator = '=';
         }
+
         return $this->whereFunctionCallHandler($key, 'DATE', $operator, $value);
     }
 
@@ -1138,8 +1253,8 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string|Raw $key
-     * @param string $prefix
-     * @param string $operator
+     * @param string     $prefix
+     * @param string     $operator
      *
      * @return static
      */
@@ -1159,11 +1274,10 @@ class QueryBuilderHandler implements HasConnection
         return $this->{$operator . 'Where'}($this->raw("{$key} IS{$prefix} NULL"));
     }
 
-
     /**
      * Runs a transaction
      *
-     * @param \Closure(Transaction):void $callback
+     * @param Closure(Transaction):void $callback
      *
      * @return static
      */
@@ -1197,10 +1311,11 @@ class QueryBuilderHandler implements HasConnection
      * Handles the transaction call.
      * Catches any WPDB Errors (printed)
      *
-     * @param Closure    $callback
+     * @param Closure     $callback
      * @param Transaction $transaction
      *
      * @return void
+     *
      * @throws Exception
      */
     protected function handleTransactionCall(Closure $callback, Transaction $transaction): void
@@ -1220,36 +1335,34 @@ class QueryBuilderHandler implements HasConnection
         }
     }
 
-    /*************************************************************************/
-    /*************************************************************************/
-    /*************************************************************************/
-    /**                              JOIN JOIN                              **/
-    /**                                 JOIN                                **/
-    /**                              JOIN JOIN                              **/
-    /*************************************************************************/
-    /*************************************************************************/
-    /*************************************************************************/
+    /**
+     * JOIN JOIN
+     **/
+    /**
+     * JOIN
+     **/
+    /**
+     * JOIN JOIN
+     **/
 
     /**
-     * @param string|Raw $table
+     * @param string|Raw         $table
      * @param string|Raw|Closure $key
-     * @param string|null $operator
-     * @param mixed $value
-     * @param string $type
+     * @param string|null        $operator
+     * @param mixed              $value
+     * @param string             $type
      *
      * @return static
      */
     public function join($table, $key, ?string $operator = null, $value = null, $type = 'inner')
     {
         // Potentially cast key from JSON
-        if ($this->jsonHandler->isJsonSelector($key)) {
-            /** @var string $key */
-            $key = $this->jsonHandler->extractAndUnquoteFromJsonSelector($key); /** @phpstan-ignore-line */
+        if (is_string($key) && $this->jsonHandler->isJsonSelector($key)) {
+            $key = $this->jsonHandler->extractAndUnquoteFromJsonSelector($key);
         }
 
         // Potentially cast value from json
-        if ($this->jsonHandler->isJsonSelector($value)) {
-            /** @var string $value */
+        if (is_string($value) && $this->jsonHandler->isJsonSelector($value)) {
             $value = $this->jsonHandler->extractAndUnquoteFromJsonSelector($value);
         }
 
@@ -1267,15 +1380,16 @@ class QueryBuilderHandler implements HasConnection
         $key($joinBuilder);
         $table = $this->addTablePrefix($table, false);
         // Get the criteria only query from the joinBuilder object
-        $this->statements['joins'][] = compact('type', 'table', 'joinBuilder');
+        $this->statements['joins'][] = new JoinStatement($type, $table, $joinBuilder);
+
         return $this;
     }
 
     /**
-     * @param string|Raw $table
+     * @param string|Raw         $table
      * @param string|Raw|Closure $key
-     * @param string|null $operator
-     * @param mixed $value
+     * @param string|null        $operator
+     * @param mixed              $value
      *
      * @return static
      */
@@ -1285,10 +1399,10 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $table
+     * @param string|Raw         $table
      * @param string|Raw|Closure $key
-     * @param string|null $operator
-     * @param mixed $value
+     * @param string|null        $operator
+     * @param mixed              $value
      *
      * @return static
      */
@@ -1298,10 +1412,10 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $table
+     * @param string|Raw         $table
      * @param string|Raw|Closure $key
-     * @param string|null $operator
-     * @param mixed $value
+     * @param string|null        $operator
+     * @param mixed              $value
      *
      * @return static
      */
@@ -1311,10 +1425,10 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $table
+     * @param string|Raw         $table
      * @param string|Raw|Closure $key
-     * @param string|null $operator
-     * @param mixed $value
+     * @param string|null        $operator
+     * @param mixed              $value
      *
      * @return static
      */
@@ -1324,10 +1438,10 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string|Raw $table
+     * @param string|Raw         $table
      * @param string|Raw|Closure $key
-     * @param string|null $operator
-     * @param mixed $value
+     * @param string|null        $operator
+     * @param mixed              $value
      *
      * @return static
      */
@@ -1339,16 +1453,18 @@ class QueryBuilderHandler implements HasConnection
     /**
      * Shortcut to join 2 tables on the same key name with equals
      *
-     * @param string $table
-     * @param string $key
-     * @param string $type
+     * @param  string $table
+     * @param  string $key
+     * @param  string $type
+     *
      * @return self
+     *
      * @throws Exception If base table is set as more than 1 or 0
      */
     public function joinUsing(string $table, string $key, string $type = 'INNER'): self
     {
-        if (!array_key_exists('tables', $this->statements) || count($this->statements['tables']) !== 1) {
-            throw new Exception("JoinUsing can only be used with a single table set as the base of the query", 1);
+        if (!array_key_exists('tables', $this->statements) || 1 !== count($this->statements['tables'])) {
+            throw new Exception('JoinUsing can only be used with a single table set as the base of the query', 1);
         }
         $baseTable = end($this->statements['tables']);
 
@@ -1358,14 +1474,15 @@ class QueryBuilderHandler implements HasConnection
         }
 
         $remoteKey = $table = $this->addTablePrefix("{$table}.{$key}", true);
-        $localKey = $table = $this->addTablePrefix("{$baseTable}.{$key}", true);
+        $localKey  = $table = $this->addTablePrefix("{$baseTable}.{$key}", true);
+
         return $this->join($table, $remoteKey, '=', $localKey, $type);
     }
 
     /**
      * Add a raw query
      *
-     * @param string|Raw $value
+     * @param string|Raw    $value
      * @param mixed|mixed[] $bindings
      *
      * @return Raw
@@ -1407,9 +1524,9 @@ class QueryBuilderHandler implements HasConnection
 
     /**
      * @param string|Raw|Closure $key
-     * @param string|null      $operator
-     * @param mixed|null       $value
-     * @param string $joiner
+     * @param string|null        $operator
+     * @param mixed|null         $value
+     * @param string             $joiner
      *
      * @return static
      */
@@ -1424,14 +1541,13 @@ class QueryBuilderHandler implements HasConnection
             $key = $this->jsonHandler->extractAndUnquoteFromJsonSelector($key);
         }
 
-        $this->statements['wheres'][] = compact('key', 'operator', 'value', 'joiner');
+        $this->statements['wheres'][] = new CriteriaStatement($key, $operator, $value, $joiner);
+
         return $this;
     }
 
-
-
     /**
-     * @param string $key
+     * @param string             $key
      * @param mixed|mixed[]|bool $value
      *
      * @return void
@@ -1450,7 +1566,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string $event
+     * @param string     $event
      * @param string|Raw $table
      *
      * @return callable|null
@@ -1461,9 +1577,9 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string $event
+     * @param string     $event
      * @param string|Raw $table
-     * @param Closure $action
+     * @param Closure    $action
      *
      * @return void
      */
@@ -1479,7 +1595,7 @@ class QueryBuilderHandler implements HasConnection
     }
 
     /**
-     * @param string $event
+     * @param string     $event
      * @param string|Raw $table
      *
      * @return void

--- a/src/QueryBuilder/QueryObject.php
+++ b/src/QueryBuilder/QueryObject.php
@@ -22,9 +22,9 @@ class QueryObject
     protected $dbInstance;
 
     /**
-     * @param string $sql
+     * @param string  $sql
      * @param mixed[] $bindings
-     * @param wpdb $dbInstance
+     * @param wpdb    $dbInstance
      */
     public function __construct(string $sql, array $bindings, wpdb $dbInstance)
     {
@@ -61,16 +61,16 @@ class QueryObject
 
     /**
      * Uses WPDB::prepare() to interpolate the query passed.
-
      *
-     * @param string $query  The sql query with parameter placeholders
-     * @param mixed[]  $params The array of substitution parameters
+     * @param string  $query  The sql query with parameter placeholders
+     * @param mixed[] $params The array of substitution parameters
      *
      * @return string The interpolated query
      */
     protected function interpolateQuery($query, $params): string
     {
         // Only call this when we have valid params (avoids wpdb::prepare() incorrectly called error)
+        // @phpstan-ignore-next-line — the query builder produces a dynamic (non-literal) string by design.
         $value = empty($params) ? $query : $this->dbInstance->prepare($query, $params);
 
         return is_string($value) ? $value : '';

--- a/src/QueryBuilder/Raw.php
+++ b/src/QueryBuilder/Raw.php
@@ -15,7 +15,7 @@ class Raw
     protected $bindings;
 
     /**
-     * @param string $value
+     * @param string        $value
      * @param mixed|mixed[] $bindings
      */
     public function __construct($value, $bindings = [])
@@ -27,7 +27,8 @@ class Raw
     /**
      * Create a Raw instance with no bindings
      *
-     * @param string $value
+     * @param  string $value
+     *
      * @return self
      */
     public static function val(string $value): self

--- a/src/QueryBuilder/Sanitizer.php
+++ b/src/QueryBuilder/Sanitizer.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Self-contained value sanitiser for table and field identifiers (#48).
+ *
+ * Relocated out of WPDBAdapter so the wrapping of identifiers with the
+ * adapter's sanitizer character (e.g. backticks) is independent of the adapter
+ * itself. WPDBAdapter::wrapSanitizer() remains as a backwards-compatible
+ * delegating wrapper around this class.
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder;
+
+use Closure;
+use Pixie\QueryBuilder\Raw;
+
+class Sanitizer
+{
+    /**
+     * The character(s) used to wrap identifiers, e.g. a backtick.
+     *
+     * @var string
+     */
+    protected $sanitizer;
+
+    /**
+     * @param string $sanitizer the wrapping character(s); empty string for none
+     */
+    public function __construct(string $sanitizer = '')
+    {
+        $this->sanitizer = $sanitizer;
+    }
+
+    /**
+     * Wraps a table/field identifier with the sanitizer character.
+     *
+     * A value joined with "." (e.g. my_table.id) is wrapped per-segment, and a
+     * "*" segment is left untouched. Raw values are handed to the optional
+     * $rawParser callback (so the adapter can stringify them), and Closures are
+     * returned as-is for the caller to resolve.
+     *
+     * @param string|Raw|Closure $value
+     * @param callable|null      $rawParser fn(Raw): string used to stringify Raw values
+     *
+     * @return string|Closure
+     */
+    public function wrap($value, ?callable $rawParser = null)
+    {
+        // Raw query: hand to the caller's parser, or cast (Raw has __toString()).
+        if ($value instanceof Raw) {
+            return null !== $rawParser ? $rawParser($value) : (string) $value;
+        }
+
+        if ($value instanceof Closure) {
+            return $value;
+        }
+
+        // Separate table and field joined with a ".", like my_table.id
+        $valueArr = explode('.', $value, 2);
+
+        foreach ($valueArr as $key => $subValue) {
+            // Don't wrap "*", which is not a usual field.
+            $valueArr[$key] = '*' == trim($subValue)
+                ? $subValue
+                : $this->sanitizer . $subValue . $this->sanitizer;
+        }
+
+        // Join these back with "." and return.
+        return implode('.', $valueArr);
+    }
+
+    /**
+     * The configured sanitizer character(s).
+     *
+     * @return string
+     */
+    public function getSanitizer(): string
+    {
+        return $this->sanitizer;
+    }
+}

--- a/src/QueryBuilder/Statement/CriteriaStatement.php
+++ b/src/QueryBuilder/Statement/CriteriaStatement.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Value object for a criteria statement: where, having and nested/join criteria (#56).
+ *
+ * Shape: ['key' => mixed, 'operator' => mixed, 'value' => mixed, 'joiner' => string].
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Statement;
+
+class CriteriaStatement extends Statement
+{
+    /**
+     * @param mixed  $key
+     * @param mixed  $operator
+     * @param mixed  $value
+     * @param string $joiner
+     */
+    public function __construct($key, $operator, $value, string $joiner)
+    {
+        $this->data = [
+            'key'      => $key,
+            'operator' => $operator,
+            'value'    => $value,
+            'joiner'   => $joiner,
+        ];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getKey()
+    {
+        return $this->data['key'];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOperator()
+    {
+        return $this->data['operator'];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->data['value'];
+    }
+
+    public function getJoiner(): string
+    {
+        return (string) $this->data['joiner'];
+    }
+}

--- a/src/QueryBuilder/Statement/JoinStatement.php
+++ b/src/QueryBuilder/Statement/JoinStatement.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Value object for a JOIN statement (#56).
+ *
+ * Shape: ['type' => string, 'table' => mixed, 'joinBuilder' => mixed].
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Statement;
+
+class JoinStatement extends Statement
+{
+    /**
+     * @param string $type
+     * @param mixed  $table
+     * @param mixed  $joinBuilder
+     */
+    public function __construct(string $type, $table, $joinBuilder)
+    {
+        $this->data = [
+            'type'        => $type,
+            'table'       => $table,
+            'joinBuilder' => $joinBuilder,
+        ];
+    }
+
+    public function getType(): string
+    {
+        return (string) $this->data['type'];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTable()
+    {
+        return $this->data['table'];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getJoinBuilder()
+    {
+        return $this->data['joinBuilder'];
+    }
+}

--- a/src/QueryBuilder/Statement/OrderByStatement.php
+++ b/src/QueryBuilder/Statement/OrderByStatement.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Value object for an ORDER BY statement (#56).
+ *
+ * Shape: ['field' => string|Raw, 'type' => string].
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Statement;
+
+class OrderByStatement extends Statement
+{
+    /**
+     * @param mixed  $field
+     * @param string $type
+     */
+    public function __construct($field, string $type)
+    {
+        $this->data = [
+            'field' => $field,
+            'type'  => $type,
+        ];
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getField()
+    {
+        return $this->data['field'];
+    }
+
+    public function getType(): string
+    {
+        return (string) $this->data['type'];
+    }
+}

--- a/src/QueryBuilder/Statement/Statement.php
+++ b/src/QueryBuilder/Statement/Statement.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Base value object for query statements (#56).
+ *
+ * Statements were previously plain associative arrays built with compact() and
+ * read with array access throughout the adapter. They are now objects, but
+ * implement ArrayAccess + IteratorAggregate so every existing array-style
+ * consumer keeps working and getStatements() stays shape-compatible.
+ *
+ * @since  0.2.0
+ *
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\QueryBuilder\Statement;
+
+use ArrayAccess;
+use ArrayIterator;
+use IteratorAggregate;
+use ReturnTypeWillChange;
+
+/**
+ * @implements ArrayAccess<string, mixed>
+ * @implements IteratorAggregate<string, mixed>
+ */
+abstract class Statement implements ArrayAccess, IteratorAggregate
+{
+    /**
+     * The statement's backing data.
+     *
+     * @var array<array-key, mixed>
+     */
+    protected $data = [];
+
+    /**
+     * @param mixed $offset
+     */
+    public function offsetExists($offset): bool
+    {
+        return isset($this->data[$offset]);
+    }
+
+    /**
+     * @param mixed $offset
+     *
+     * @return mixed
+     */
+    #[ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset] ?? null;
+    }
+
+    /**
+     * @param mixed $offset
+     * @param mixed $value
+     */
+    public function offsetSet($offset, $value): void
+    {
+        if (null === $offset) {
+            $this->data[] = $value;
+
+            return;
+        }
+
+        $this->data[$offset] = $value;
+    }
+
+    /**
+     * @param mixed $offset
+     */
+    public function offsetUnset($offset): void
+    {
+        unset($this->data[$offset]);
+    }
+
+    /**
+     * @return ArrayIterator<array-key, mixed>
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->data);
+    }
+
+    /**
+     * The statement as its original associative-array shape.
+     *
+     * @return array<array-key, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->data;
+    }
+}

--- a/src/QueryBuilder/TablePrefixer.php
+++ b/src/QueryBuilder/TablePrefixer.php
@@ -3,20 +3,22 @@
 namespace Pixie\QueryBuilder;
 
 use Closure;
-use Pixie\Exception;
 use Pixie\Connection;
+use Pixie\Exception;
 use Pixie\QueryBuilder\Raw;
+
+use function substr_count;
 
 trait TablePrefixer
 {
     /**
-         * Add table prefix (if given) on given string.
-         *
-         * @param array<string|int, string|int|float|bool|Raw|Closure>|string|int|float|bool|Raw|Closure     $values
-         * @param bool $tableFieldMix If we have mixes of field and table names with a "."
-         *
-         * @return mixed|mixed[]
-         */
+     * Add table prefix (if given) on given string.
+     *
+     * @param array<string|int, string|int|float|bool|Raw|Closure>|string|int|float|bool|Raw|Closure $values
+     * @param bool                                                                                   $tableFieldMix If we have mixes of field and table names with a "."
+     *
+     * @return mixed|mixed[]
+     */
     public function addTablePrefix($values, bool $tableFieldMix = true)
     {
         if (is_null($this->getTablePrefix())) {
@@ -50,12 +52,11 @@ trait TablePrefixer
             }
 
             // Do prefix if the target is an expression or function.
-            if (
-                !$tableFieldMix
+            if (!$tableFieldMix
                 || (
                     is_string($target) // Must be a string
-                    && (bool) preg_match('/^[A-Za-z0-9_.]+$/', $target) // Can only contain letters, numbers, underscore and full stops
-                    && 1 === \substr_count($target, '.') // Contains a single full stop ONLY.
+                && (bool) preg_match('/^[A-Za-z0-9_.]+$/', $target) // Can only contain letters, numbers, underscore and full stops
+                && 1 === substr_count($target, '.') // Contains a single full stop ONLY.
                 )
             ) {
                 $target = $this->getTablePrefix() . $target;
@@ -76,9 +77,9 @@ trait TablePrefixer
     protected function getTablePrefix(): ?string
     {
         $adapterConfig = $this->getConnection()->getAdapterConfig();
-        return isset($adapterConfig[Connection::PREFIX])
-            ? $adapterConfig[Connection::PREFIX]
-            : null;
+
+        return $adapterConfig[Connection::PREFIX]
+            ?? null;
     }
 
     abstract public function getConnection(): Connection;

--- a/src/QueryBuilder/WPDBAdapter.php
+++ b/src/QueryBuilder/WPDBAdapter.php
@@ -4,13 +4,14 @@ namespace Pixie\QueryBuilder;
 
 use Closure;
 use Pixie\Binding;
-use Pixie\Exception;
-
 use Pixie\Connection;
-
-use Pixie\QueryBuilder\Raw;
-
+use Pixie\Exception;
+use Pixie\QueryBuilder\Handler\JoinConditionHandler;
+use Pixie\QueryBuilder\Handler\SelectConditionHandler;
+use Pixie\QueryBuilder\Handler\TableConditionHandler;
+use Pixie\QueryBuilder\Handler\WhereConditionHandler;
 use Pixie\QueryBuilder\NestedCriteria;
+use Pixie\QueryBuilder\Raw;
 
 use function is_bool;
 use function is_float;
@@ -23,7 +24,7 @@ class WPDBAdapter
     protected $sanitizer = '';
 
     /**
-     * @var \Pixie\Connection
+     * @var Connection
      */
     protected $connection;
 
@@ -32,10 +33,46 @@ class WPDBAdapter
      */
     protected $container;
 
+    /**
+     * Self-contained identifier sanitiser (#48).
+     *
+     * @var Sanitizer
+     */
+    protected $sanitizerHandler;
+
+    /**
+     * Self-contained condition handlers (#31).
+     *
+     * @var TableConditionHandler
+     */
+    protected $tableConditionHandler;
+
+    /**
+     * @var SelectConditionHandler
+     */
+    protected $selectConditionHandler;
+
+    /**
+     * @var WhereConditionHandler
+     */
+    protected $whereConditionHandler;
+
+    /**
+     * @var JoinConditionHandler
+     */
+    protected $joinConditionHandler;
+
     public function __construct(Connection $connection)
     {
-        $this->connection = $connection;
-        $this->container  = $this->connection->getContainer();
+        $this->connection       = $connection;
+        $this->container        = $this->connection->getContainer();
+        $this->sanitizerHandler = new Sanitizer($this->sanitizer);
+
+        // Self-contained condition handlers (#31).
+        $this->tableConditionHandler  = new TableConditionHandler($this);
+        $this->selectConditionHandler = new SelectConditionHandler($this);
+        $this->whereConditionHandler  = new WhereConditionHandler($this);
+        $this->joinConditionHandler   = new JoinConditionHandler($this);
     }
 
     /**
@@ -55,10 +92,10 @@ class WPDBAdapter
             $statements['selects'][] = '*';
         }
 
-        // From
-        $tables = $this->arrayStr($statements['tables'], ', ');
-        // Select
-        $selects = $this->arrayStr($statements['selects'], ', ');
+        // From (delegated to TableConditionHandler #31)
+        $tables = $this->tableConditionHandler->build($statements['tables']);
+        // Select (delegated to SelectConditionHandler #31)
+        $selects = $this->selectConditionHandler->build($statements['selects']);
 
         // Wheres
         list($whereCriteria, $whereBindings) = $this->buildCriteriaWithType($statements, 'wheres', 'WHERE');
@@ -95,7 +132,9 @@ class WPDBAdapter
         // Joins
         $joinString = $this->buildJoin($statements);
 
-        /** @var string[] */
+        /**
+         * @var string[]
+         */
         $sqlArray = [
             'SELECT' . (isset($statements['distinct']) ? ' DISTINCT' : ''),
             $selects,
@@ -124,7 +163,7 @@ class WPDBAdapter
      * Build just criteria part of the query
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param bool $bindValues
+     * @param bool                                 $bindValues
      *
      * @return array{sql:string[]|string, bindings:array<mixed>}
      */
@@ -144,8 +183,8 @@ class WPDBAdapter
      * Build a generic insert/ignore/replace query
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param array<string, mixed> $data
-     * @param string $type
+     * @param array<string, mixed>                 $data
+     * @param string                               $type
      *
      * @return array{sql:string, bindings:mixed[]}
      *
@@ -183,11 +222,11 @@ class WPDBAdapter
         }
 
         $sqlArray = [
-        $type . ' INTO',
-        $this->wrapSanitizer($table),
-        '(' . $this->arrayStr($keys, ',') . ')',
-        'VALUES',
-        '(' . $this->arrayStr($values, ',') . ')',
+            $type . ' INTO',
+            $this->wrapSanitizer($table),
+            '(' . $this->arrayStr($keys, ',') . ')',
+            'VALUES',
+            '(' . $this->arrayStr($values, ',') . ')',
         ];
 
         if (isset($statements['onduplicate'])) {
@@ -219,11 +258,13 @@ class WPDBAdapter
     /**
      * Attempts to stringify a single of values.
      *
+     * Public so the extracted condition handlers (#31) can reuse it.
+     *
      * @param string|Closure|Raw $value
      *
      * @return string|null
      */
-    protected function stringifyValue($value): ?string
+    public function stringifyValue($value): ?string
     {
         if ($value instanceof Closure) {
             $value = $value();
@@ -242,7 +283,7 @@ class WPDBAdapter
      * Build Insert query
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param array<string, mixed> $data $data
+     * @param array<string, mixed>                 $data       $data
      *
      * @return array{sql:string, bindings:mixed[]}
      *
@@ -257,7 +298,7 @@ class WPDBAdapter
      * Build Insert Ignore query
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param array<string, mixed> $data $data
+     * @param array<string, mixed>                 $data       $data
      *
      * @return array{sql:string, bindings:mixed[]}
      *
@@ -272,7 +313,7 @@ class WPDBAdapter
      * Build Insert Ignore query
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param array<string, mixed> $data $data
+     * @param array<string, mixed>                 $data       $data
      *
      * @return array{sql:string, bindings:mixed[]}
      *
@@ -322,7 +363,7 @@ class WPDBAdapter
      * Build update query
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param array<string, mixed> $data
+     * @param array<string, mixed>                 $data
      *
      * @return array{sql:string, bindings:mixed[]}
      *
@@ -402,11 +443,11 @@ class WPDBAdapter
      * But it does wrap sanitizer and trims last glue
      *
      * @param array<string|int, string> $pieces
-     * @param string $glue
+     * @param string                    $glue
      *
      * @return string
      */
-    protected function arrayStr(array $pieces, string $glue): string
+    public function arrayStr(array $pieces, string $glue): string
     {
         $str = '';
         foreach ($pieces as $key => $piece) {
@@ -427,7 +468,7 @@ class WPDBAdapter
      *
      * @return string
      */
-    protected function concatenateQuery(array $pieces): string
+    public function concatenateQuery(array $pieces): string
     {
         $str = '';
         foreach ($pieces as $piece) {
@@ -440,19 +481,21 @@ class WPDBAdapter
     /**
      * Gets the type of a value, either from a binding or infered
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return string
      */
     public function getType($value): string
     {
-        return $value instanceof Binding && $value->getType() !== null
-            ? $value->getType() : $this->inferType($value) ;
+        return $value instanceof Binding && null !== $value->getType()
+            ? $value->getType() : $this->inferType($value);
     }
 
     /**
      * Get the value from a possible Bindings object.
      *
-     * @param mixed $value
+     * @param  mixed $value
+     *
      * @return mixed
      */
     public function getValue($value)
@@ -463,12 +506,14 @@ class WPDBAdapter
     /**
      * Attempts to parse a raw query, if bindings are defined then they will be bound first.
      *
-     * @param Raw $raw
+     * @param    Raw $raw
+     *
      * @requires string
      */
     public function parseRaw(Raw $raw): string
     {
         $bindings = $raw->getBindings();
+
         return 0 === count($bindings)
             ? (string) $raw
             : $this->interpolateQuery($raw->getValue(), $bindings);
@@ -477,8 +522,9 @@ class WPDBAdapter
     /**
      * Interpolates a query
      *
-     * @param string $query
-     * @param array<mixed> $bindings
+     * @param  string       $query
+     * @param  array<mixed> $bindings
+     *
      * @return string
      */
     public function interpolateQuery(string $query, array $bindings = []): string
@@ -487,9 +533,10 @@ class WPDBAdapter
             return $query;
         }
 
-
         $bindings = array_map([$this, 'getValue'], $bindings);
-        $query = $this->connection->getDbInstance()->prepare($query, $bindings) ;
+        // @phpstan-ignore-next-line — the query builder produces a dynamic (non-literal) string by design.
+        $query = $this->connection->getDbInstance()->prepare($query, $bindings);
+
         return is_string($query) ? $query : '';
     }
 
@@ -497,11 +544,11 @@ class WPDBAdapter
      * Build generic criteria string and bindings from statements, like "a = b and c = ?"
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param bool $bindValues
+     * @param bool                                 $bindValues
      *
      * @return array{0:string,1:string[]}
      */
-    protected function buildCriteria(array $statements, bool $bindValues = true): array
+    public function buildCriteria(array $statements, bool $bindValues = true): array
     {
         $criteria = '';
         $bindings = [];
@@ -511,7 +558,9 @@ class WPDBAdapter
 
             // If the value is a Raw Binding, cast to raw
             if ($value instanceof Binding && Binding::RAW === $value->getType()) {
-                /** @var Raw */
+                /**
+                 * @var Raw
+                 */
                 $value = $value->getValue();
             }
 
@@ -549,23 +598,27 @@ class WPDBAdapter
                         $value[1] = $this->getValue($value[1]);
 
                         // Parse any raws.
-                        $value = array_map(function ($value) {
-                            return $value instanceof Raw
+                        $value = array_map(
+                            function ($value) {
+                                return $value instanceof Raw
                                 ? $this->parseRaw($value)
                                 : $value;
-                        }, $value);
+                            },
+                            $value
+                        );
                         break;
                     default:
                         $valuePlaceholder = '';
                         foreach ($statement['value'] as $subValue) {
                             // Get its value.
                             if ($this->getValue($subValue) instanceof Raw) {
-                                /** @var Raw $subValue */
+                                /**
+                                 * @var Raw $subValue
+                                 */
                                 $subValue = $this->getValue($subValue);
                                 $valuePlaceholder .= sprintf('%s, ', $this->parseRaw($subValue));
                                 continue;
                             }
-
 
                             // Add in format placeholders.
                             $valuePlaceholder .= sprintf('%s, ', $this->getType($subValue)); // glynn
@@ -630,60 +683,32 @@ class WPDBAdapter
     /**
      * Wrap values with adapter's sanitizer like, '`'
      *
+     * The wrapping logic now lives in the self-contained Sanitizer class (#48);
+     * this method is retained as a backwards-compatible delegating wrapper.
+     *
      * @param string|Raw|Closure $value
      *
      * @return string|Closure
      */
     public function wrapSanitizer($value)
     {
-        // Its a raw query, just cast as string, object has __toString()
-        if ($value instanceof Raw) {
-            return $this->parseRaw($value);
-        } elseif ($value instanceof Closure) {
-            return $value;
-        }
-
-        // Separate our table and fields which are joined with a ".",
-        // like my_table.id
-        $valueArr = explode('.', $value, 2);
-
-        foreach ($valueArr as $key => $subValue) {
-            // Don't wrap if we have *, which is not a usual field
-            $valueArr[$key] = '*' == trim($subValue) ? $subValue : $this->sanitizer . $subValue . $this->sanitizer;
-        }
-
-        // Join these back with "." and return
-        return implode('.', $valueArr);
+        return $this->sanitizerHandler->wrap($value, [$this, 'parseRaw']);
     }
 
     /**
      * Build criteria string and binding with various types added, like WHERE and Having
      *
      * @param array<string|Closure, mixed|mixed[]> $statements
-     * @param string $key
-     * @param string $type
-     * @param bool $bindValues
+     * @param string                               $key
+     * @param string                               $type
+     * @param bool                                 $bindValues
      *
      * @return array{0:string, 1:string[]}
      */
     protected function buildCriteriaWithType(array $statements, string $key, string $type, bool $bindValues = true)
     {
-        $criteria = '';
-        $bindings = [];
-
-        if (isset($statements[$key])) {
-            // Get the generic/adapter agnostic criteria string from parent
-            list($criteria, $bindings) = $this->buildCriteria($statements[$key], $bindValues);
-
-            if ($criteria) {
-                $criteria = $type . ' ' . $criteria;
-            }
-        }
-
-        // Remove any multiple whitespace.
-        $criteria = (string) preg_replace('!\s+!', ' ', $criteria);
-
-        return [$criteria, $bindings];
+        // Delegated to the self-contained WhereConditionHandler (#31).
+        return $this->whereConditionHandler->build($statements, $key, $type, $bindValues);
     }
 
     /**
@@ -695,37 +720,7 @@ class WPDBAdapter
      */
     protected function buildJoin(array $statements): string
     {
-        $sql = '';
-
-        if (!array_key_exists('joins', $statements) || !is_array($statements['joins'])) {
-            return $sql;
-        }
-
-        foreach ($statements['joins'] as $joinArr) {
-            if (is_array($joinArr['table'])) {
-                $mainTable  = $this->stringifyValue($this->wrapSanitizer($joinArr['table'][0]));
-                $aliasTable = $this->stringifyValue($this->wrapSanitizer($joinArr['table'][1]));
-                $table      = $mainTable . ' AS ' . $aliasTable;
-            } else {
-                $table = $joinArr['table'] instanceof Raw
-                    ? $this->parseRaw($joinArr['table'])
-                    : $this->wrapSanitizer($joinArr['table']);
-            }
-            $joinBuilder = $joinArr['joinBuilder'];
-
-            /** @var string[] */
-            $sqlArr = [
-                $sql,
-                strtoupper($joinArr['type']),
-                'JOIN',
-                $table,
-                'ON',
-                $joinBuilder->getQuery('criteriaOnly', false)->getSql(),
-            ];
-
-            $sql = $this->concatenateQuery($sqlArr);
-        }
-
-        return $sql;
+        // Delegated to the self-contained JoinConditionHandler (#31).
+        return $this->joinConditionHandler->build($statements);
     }
 }

--- a/src/WpDbException.php
+++ b/src/WpDbException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Exception thrown when WPDB reports an error during query execution.
+ *
+ * Only thrown when the connection has been configured with the opt-in
+ * Connection::THROW_ON_ERROR flag; by default WPDB errors continue to fail
+ * silently to preserve backwards compatibility.
+ */
+
+namespace Pixie;
+
+use Pixie\Exception;
+use wpdb;
+
+use function sprintf;
+
+class WpDbException extends Exception
+{
+    /**
+     * Builds an exception from the last error held by a WPDB instance.
+     *
+     * @param wpdb       $wpdb the WPDB instance whose last_error will be read
+     * @param string|null $sql  the SQL statement that triggered the error, if known
+     */
+    public static function fromWpdb(wpdb $wpdb, ?string $sql = null): self
+    {
+        $message = '' !== $wpdb->last_error
+            ? $wpdb->last_error
+            : 'Unknown WPDB error';
+
+        if (null !== $sql && '' !== $sql) {
+            $message .= sprintf(' [SQL: %s]', $sql);
+        }
+
+        return new self($message);
+    }
+}

--- a/src/loader.php
+++ b/src/loader.php
@@ -1,7 +1,5 @@
 <?php
 
-
-
 /**
  * Pixie WPDB Static Loader
  *
@@ -19,77 +17,107 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- * @author Glynn Quelch <glynn@pinkcrab.co.uk>
+ * @author  Glynn Quelch <glynn@pinkcrab.co.uk>
  * @license http://www.opensource.org/licenses/mit-license.html  MIT License
- * @package Gin0115\Pixie WPDB
- * @since 0.0.1
+ *
+ * @since   0.0.1
  */
 
 // Generated code start...
-if (!interface_exists(Pixie\HasConnection::class)) {
-    require_once __DIR__ . '/HasConnection.php';
-}
 if (!trait_exists(Pixie\QueryBuilder\TablePrefixer::class)) {
-    require_once __DIR__ . '/QueryBuilder/TablePrefixer.php';
+    include_once __DIR__ . '/QueryBuilder/TablePrefixer.php';
 }
-if (!class_exists(Pixie\Binding::class)) {
-    require_once __DIR__ . '/Binding.php';
-}
-if (!class_exists(Pixie\QueryBuilder\QueryBuilderHandler::class)) {
-    require_once __DIR__ . '/QueryBuilder/QueryBuilderHandler.php';
-}
-if (!class_exists(Pixie\QueryBuilder\Transaction::class)) {
-    require_once __DIR__ . '/QueryBuilder/Transaction.php';
-}
-if (!class_exists(Pixie\QueryBuilder\Raw::class)) {
-    require_once __DIR__ . '/QueryBuilder/Raw.php';
-}
-if (!class_exists(Pixie\JSON\JsonHandler::class)) {
-    require_once __DIR__ . '/JSON/JsonHandler.php';
-}
-if (!class_exists(Pixie\EventHandler::class)) {
-    require_once __DIR__ . '/EventHandler.php';
-}
-if (!class_exists(Pixie\QueryBuilder\QueryObject::class)) {
-    require_once __DIR__ . '/QueryBuilder/QueryObject.php';
-}
-if (!class_exists(Pixie\QueryBuilder\NestedCriteria::class)) {
-    require_once __DIR__ . '/QueryBuilder/NestedCriteria.php';
-}
-if (!class_exists(Pixie\QueryBuilder\JoinBuilder::class)) {
-    require_once __DIR__ . '/QueryBuilder/JoinBuilder.php';
-}
-if (!class_exists(Pixie\Event::class)) {
-    require_once __DIR__ . '/Event.php';
+if (!interface_exists(Pixie\HasConnection::class)) {
+    include_once __DIR__ . '/HasConnection.php';
 }
 if (!class_exists(Pixie\JSON\JsonSelectorHandler::class)) {
-    require_once __DIR__ . '/JSON/JsonSelectorHandler.php';
+    include_once __DIR__ . '/JSON/JsonSelectorHandler.php';
 }
 if (!class_exists(Pixie\JSON\JsonSelector::class)) {
-    require_once __DIR__ . '/JSON/JsonSelector.php';
+    include_once __DIR__ . '/JSON/JsonSelector.php';
 }
-if (!class_exists(Pixie\Connection::class)) {
-    require_once __DIR__ . '/Connection.php';
+if (!class_exists(Pixie\EventHandler::class)) {
+    include_once __DIR__ . '/EventHandler.php';
+}
+if (!class_exists(Pixie\WpDbException::class)) {
+    include_once __DIR__ . '/WpDbException.php';
 }
 if (!class_exists(Pixie\QueryBuilder\JsonQueryBuilder::class)) {
-    require_once __DIR__ . '/QueryBuilder/JsonQueryBuilder.php';
-}
-if (!class_exists(Pixie\Hydration\Hydrator::class)) {
-    require_once __DIR__ . '/Hydration/Hydrator.php';
+    include_once __DIR__ . '/QueryBuilder/JsonQueryBuilder.php';
 }
 if (!class_exists(Pixie\QueryBuilder\WPDBAdapter::class)) {
-    require_once __DIR__ . '/QueryBuilder/WPDBAdapter.php';
+    include_once __DIR__ . '/QueryBuilder/WPDBAdapter.php';
 }
-if (!class_exists(Pixie\Exception::class)) {
-    require_once __DIR__ . '/Exception.php';
+if (!class_exists(Pixie\QueryBuilder\Handler\TableConditionHandler::class)) {
+    include_once __DIR__ . '/QueryBuilder/Handler/TableConditionHandler.php';
 }
-if (!class_exists(Pixie\QueryBuilder\TransactionHaltException::class)) {
-    require_once __DIR__ . '/QueryBuilder/TransactionHaltException.php';
+if (!class_exists(Pixie\QueryBuilder\Statement\CriteriaStatement::class)) {
+    include_once __DIR__ . '/QueryBuilder/Statement/CriteriaStatement.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Statement\JoinStatement::class)) {
+    include_once __DIR__ . '/QueryBuilder/Statement/JoinStatement.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Raw::class)) {
+    include_once __DIR__ . '/QueryBuilder/Raw.php';
+}
+if (!class_exists(Pixie\QueryBuilder\JoinBuilder::class)) {
+    include_once __DIR__ . '/QueryBuilder/JoinBuilder.php';
+}
+if (!class_exists(Pixie\Connection::class)) {
+    include_once __DIR__ . '/Connection.php';
 }
 if (!class_exists(Pixie\AliasFacade::class)) {
-    require_once __DIR__ . '/AliasFacade.php';
+    include_once __DIR__ . '/AliasFacade.php';
+}
+if (!class_exists(Pixie\Binding::class)) {
+    include_once __DIR__ . '/Binding.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Handler\WhereConditionHandler::class)) {
+    include_once __DIR__ . '/QueryBuilder/Handler/WhereConditionHandler.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Statement\OrderByStatement::class)) {
+    include_once __DIR__ . '/QueryBuilder/Statement/OrderByStatement.php';
+}
+if (!class_exists(Pixie\QueryBuilder\NestedCriteria::class)) {
+    include_once __DIR__ . '/QueryBuilder/NestedCriteria.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Statement\Statement::class)) {
+    include_once __DIR__ . '/QueryBuilder/Statement/Statement.php';
+}
+if (!class_exists(Pixie\QueryBuilder\QueryObject::class)) {
+    include_once __DIR__ . '/QueryBuilder/QueryObject.php';
+}
+if (!class_exists(Pixie\QueryBuilder\QueryBuilderHandler::class)) {
+    include_once __DIR__ . '/QueryBuilder/QueryBuilderHandler.php';
+}
+if (!class_exists(Pixie\QueryBuilder\TransactionHaltException::class)) {
+    include_once __DIR__ . '/QueryBuilder/TransactionHaltException.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Transaction::class)) {
+    include_once __DIR__ . '/QueryBuilder/Transaction.php';
+}
+if (!class_exists(Pixie\Hydration\Hydrator::class)) {
+    include_once __DIR__ . '/Hydration/Hydrator.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Sanitizer::class)) {
+    include_once __DIR__ . '/QueryBuilder/Sanitizer.php';
 }
 if (!class_exists(Pixie\JSON\JsonExpressionFactory::class)) {
-    require_once __DIR__ . '/JSON/JsonExpressionFactory.php';
+    include_once __DIR__ . '/JSON/JsonExpressionFactory.php';
 }
-// CREATED ON Fri 15th April 2022
+if (!class_exists(Pixie\QueryBuilder\Handler\JoinConditionHandler::class)) {
+    include_once __DIR__ . '/QueryBuilder/Handler/JoinConditionHandler.php';
+}
+if (!class_exists(Pixie\JSON\JsonHandler::class)) {
+    include_once __DIR__ . '/JSON/JsonHandler.php';
+}
+if (!class_exists(Pixie\QueryBuilder\Handler\SelectConditionHandler::class)) {
+    include_once __DIR__ . '/QueryBuilder/Handler/SelectConditionHandler.php';
+}
+if (!class_exists(Pixie\Event::class)) {
+    include_once __DIR__ . '/Event.php';
+}
+if (!class_exists(Pixie\Exception::class)) {
+    include_once __DIR__ . '/Exception.php';
+}
+// CREATED ON Thu 4th June 2026

--- a/tests/JSON/TestIntegrationWithWPDB.php
+++ b/tests/JSON/TestIntegrationWithWPDB.php
@@ -214,10 +214,10 @@ class TestIntegrationWithWPDB extends WP_UnitTestCase
         $this->assertEquals('a', $arrayValues->string);
         $this->assertEquals('[1, 2, 3, 4]', $arrayValues->jsonVALUE);
         $this->assertCount(4, \json_decode($arrayValues->jsonVALUE));
-        $this->assertContains('1', \json_decode($arrayValues->jsonVALUE));
-        $this->assertContains('2', \json_decode($arrayValues->jsonVALUE));
-        $this->assertContains('3', \json_decode($arrayValues->jsonVALUE));
-        $this->assertContains('4', \json_decode($arrayValues->jsonVALUE));
+        $this->assertContainsEquals('1', \json_decode($arrayValues->jsonVALUE));
+        $this->assertContainsEquals('2', \json_decode($arrayValues->jsonVALUE));
+        $this->assertContainsEquals('3', \json_decode($arrayValues->jsonVALUE));
+        $this->assertContainsEquals('4', \json_decode($arrayValues->jsonVALUE));
 
         // Pluck a single item from an array using its key.
         $pluckArrayValue = $this->jsonQueryBuilderProvider('mock_')

--- a/tests/JSON/TestJsonPhase2Expressions.php
+++ b/tests/JSON/TestJsonPhase2Expressions.php
@@ -131,6 +131,35 @@ class TestJsonPhase2Expressions extends WP_UnitTestCase
         );
     }
 
+    /** @testdox [#28] A Raw value is passed through unquoted into a modification expression. */
+    public function testRawValuePassthrough(): void
+    {
+        $raw = new \Pixie\QueryBuilder\Raw('NOW()');
+        $this->assertEquals(
+            'JSON_SET(data, "$.ts", NOW())',
+            (string) $this->exprFactory()->set('data', 'ts', $raw)
+        );
+    }
+
+    /** @testdox [#28] A Raw document is passed through unquoted into a merge expression. */
+    public function testRawDocumentPassthrough(): void
+    {
+        $raw = new \Pixie\QueryBuilder\Raw("JSON_OBJECT('a', 1)");
+        $this->assertEquals(
+            "JSON_MERGE_PATCH(data, JSON_OBJECT('a', 1))",
+            (string) $this->exprFactory()->mergePatch('data', $raw)
+        );
+    }
+
+    /** @testdox [#28] A float value is inlined numerically. */
+    public function testFloatValue(): void
+    {
+        $this->assertEquals(
+            'JSON_SET(data, "$.ratio", 1.5)',
+            (string) $this->exprFactory()->set('data', 'ratio', 1.5)
+        );
+    }
+
     /** @testdox [#28] orderByCast() generates a CAST over JSON_UNQUOTE(JSON_EXTRACT()). */
     public function testOrderByCast(): void
     {

--- a/tests/JSON/TestJsonPhase2Expressions.php
+++ b/tests/JSON/TestJsonPhase2Expressions.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for JSON Support Phase 2 modification expressions (#28).
+ *
+ * Verifies the verbose, portable JSON_* function syntax (never ->/->>) is
+ * generated for set/insert/replace/array append+insert/remove/merge variants,
+ * plus the orderBy cast-to-type helper.
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\JSON;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\JSON\JsonExpressionFactory;
+use Pixie\QueryBuilder\JsonQueryBuilder;
+
+class TestJsonPhase2Expressions extends WP_UnitTestCase
+{
+    private function exprFactory(): JsonExpressionFactory
+    {
+        return new JsonExpressionFactory(new Connection(new Logable_WPDB(), []));
+    }
+
+    private function jsonQb(): JsonQueryBuilder
+    {
+        return new JsonQueryBuilder(new Connection(new Logable_WPDB(), []));
+    }
+
+    /** @testdox [#28] set() generates JSON_SET. */
+    public function testSet(): void
+    {
+        $this->assertEquals(
+            'JSON_SET(data, "$.foo.bar", \'baz\')',
+            (string) $this->exprFactory()->set('data', ['foo', 'bar'], 'baz')
+        );
+    }
+
+    /** @testdox [#28] insert() generates JSON_INSERT. */
+    public function testInsert(): void
+    {
+        $this->assertEquals(
+            'JSON_INSERT(data, "$.foo", 5)',
+            (string) $this->exprFactory()->insert('data', 'foo', 5)
+        );
+    }
+
+    /** @testdox [#28] replace() generates JSON_REPLACE. */
+    public function testReplace(): void
+    {
+        $this->assertEquals(
+            'JSON_REPLACE(data, "$.foo", true)',
+            (string) $this->exprFactory()->replace('data', 'foo', true)
+        );
+    }
+
+    /** @testdox [#28] appendArray() generates JSON_ARRAY_APPEND. */
+    public function testAppendArray(): void
+    {
+        $this->assertEquals(
+            'JSON_ARRAY_APPEND(data, "$.list", 9)',
+            (string) $this->exprFactory()->appendArray('data', 'list', 9)
+        );
+    }
+
+    /** @testdox [#28] insertArray() generates JSON_ARRAY_INSERT with an indexed path. */
+    public function testInsertArray(): void
+    {
+        $this->assertEquals(
+            'JSON_ARRAY_INSERT(data, "$.list[1]", \'x\')',
+            (string) $this->exprFactory()->insertArray('data', ['list[1]'], 'x')
+        );
+    }
+
+    /** @testdox [#28] remove() generates JSON_REMOVE. */
+    public function testRemove(): void
+    {
+        $this->assertEquals(
+            'JSON_REMOVE(data, "$.foo.bar")',
+            (string) $this->exprFactory()->remove('data', ['foo', 'bar'])
+        );
+    }
+
+    /** @testdox [#28] mergePreserve() and merge() generate JSON_MERGE_PRESERVE with a portable JSON document. */
+    public function testMergePreserve(): void
+    {
+        $expected = 'JSON_MERGE_PRESERVE(data, JSON_EXTRACT(\'{"a":1}\', \'$\'))';
+        $this->assertEquals($expected, (string) $this->exprFactory()->mergePreserve('data', ['a' => 1]));
+        $this->assertEquals($expected, (string) $this->exprFactory()->merge('data', ['a' => 1]));
+    }
+
+    /** @testdox [#28] mergePatch() generates JSON_MERGE_PATCH with a portable JSON document. */
+    public function testMergePatch(): void
+    {
+        $this->assertEquals(
+            'JSON_MERGE_PATCH(data, JSON_EXTRACT(\'{"a":1}\', \'$\'))',
+            (string) $this->exprFactory()->mergePatch('data', ['a' => 1])
+        );
+    }
+
+    /** @testdox [#28] An array value is inlined as a portable JSON_EXTRACT document (works on MySQL & MariaDB). */
+    public function testArrayValueIsPortableJsonDocument(): void
+    {
+        $this->assertEquals(
+            'JSON_SET(data, "$.list", JSON_EXTRACT(\'[1,2,3]\', \'$\'))',
+            (string) $this->exprFactory()->set('data', 'list', [1, 2, 3])
+        );
+    }
+
+    /** @testdox [#28] A null value is inlined as NULL. */
+    public function testNullValue(): void
+    {
+        $this->assertEquals(
+            'JSON_SET(data, "$.foo", NULL)',
+            (string) $this->exprFactory()->set('data', 'foo', null)
+        );
+    }
+
+    /** @testdox [#28] Single quotes in string values are escaped. */
+    public function testStringValueEscaped(): void
+    {
+        $this->assertEquals(
+            'JSON_SET(data, "$.name", \'O\'\'Brien\')',
+            (string) $this->exprFactory()->set('data', 'name', "O'Brien")
+        );
+    }
+
+    /** @testdox [#28] orderByCast() generates a CAST over JSON_UNQUOTE(JSON_EXTRACT()). */
+    public function testOrderByCast(): void
+    {
+        $this->assertEquals(
+            'CAST(JSON_UNQUOTE(JSON_EXTRACT(data, "$.age")) AS UNSIGNED)',
+            (string) $this->exprFactory()->orderByCast('data', 'age', 'UNSIGNED')
+        );
+    }
+
+    /** @testdox [#28] orderByJson() with a cast type adds an ORDER BY using the cast expression. */
+    public function testFluentOrderByJsonWithCast(): void
+    {
+        $sql = $this->jsonQb()->table('foo')
+            ->orderByJson('data', 'age', 'DESC', 'UNSIGNED')
+            ->getQuery()->getSql();
+
+        $this->assertEquals(
+            'SELECT * FROM foo ORDER BY CAST(JSON_UNQUOTE(JSON_EXTRACT(data, "$.age")) AS UNSIGNED) DESC',
+            $sql
+        );
+    }
+
+    /** @testdox [#28][BC] orderByJson() without a cast keeps the existing extract-and-unquote behaviour. */
+    public function testFluentOrderByJsonNoCastUnchanged(): void
+    {
+        $sql = $this->jsonQb()->table('foo')
+            ->orderByJson('data', 'age', 'DESC')
+            ->getQuery()->getSql();
+
+        $this->assertEquals(
+            'SELECT * FROM foo ORDER BY JSON_UNQUOTE(JSON_EXTRACT(data, "$.age")) DESC',
+            $sql
+        );
+    }
+
+    /** @testdox [#28] A JSON modification expression composes into update(). */
+    public function testComposesIntoUpdate(): void
+    {
+        $qb  = $this->jsonQb();
+        $sql = $qb->table('foo')
+            ->where('id', '=', 1)
+            ->update(['data' => $qb->jsonExpression()->set('data', ['profile', 'name'], 'Sam')]);
+
+        // The Logable_WPDB records the prepared query.
+        $log = $qb->dbInstance()->usage_log['get_results'][0]['query'] ?? '';
+        $this->assertStringContainsString('JSON_SET(data, "$.profile.name", \'Sam\')', $log);
+    }
+}

--- a/tests/JSON/TestJsonPhase2Integration.php
+++ b/tests/JSON/TestJsonPhase2Integration.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Live-DB integration tests for JSON Support Phase 2 (#28).
+ *
+ * Proves the verbose JSON_* modification expressions actually execute against
+ * the WP PHPUnit MySQL/MariaDB instance and produce the expected stored JSON.
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\JSON;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\QueryBuilder\JsonQueryBuilder;
+
+class TestJsonPhase2Integration extends WP_UnitTestCase
+{
+    /** @var \wpdb */
+    private $wpdb;
+
+    /** @var bool */
+    protected static $created = false;
+
+    public function setUp(): void
+    {
+        global $wpdb;
+        $this->wpdb = clone $wpdb;
+        parent::setUp();
+
+        if (! static::$created) {
+            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+            \dbDelta(
+                "CREATE TABLE mock_json_p2 (
+                 id mediumint(8) unsigned NOT NULL auto_increment,
+                 jsonCol json NULL,
+                 PRIMARY KEY  (id)
+                ) COLLATE {$this->wpdb->collate}"
+            );
+            static::$created = true;
+        }
+
+        $this->wpdb->query('TRUNCATE TABLE mock_json_p2');
+    }
+
+    private function qb(): JsonQueryBuilder
+    {
+        return new JsonQueryBuilder(new Connection($this->wpdb, []));
+    }
+
+    private function seed(string $json): int
+    {
+        $this->wpdb->insert('mock_json_p2', ['jsonCol' => $json], ['%s']);
+        return (int) $this->wpdb->insert_id;
+    }
+
+    private function readJson(int $id): array
+    {
+        $row = $this->wpdb->get_row(
+            $this->wpdb->prepare('SELECT jsonCol FROM mock_json_p2 WHERE id = %d', $id)
+        );
+        return (array) \json_decode($row->jsonCol, true);
+    }
+
+    /** @testdox [#28] JSON_SET via set() updates a nested value in the live DB. */
+    public function testSetUpdatesValue(): void
+    {
+        $id = $this->seed('{"profile": {"name": "Old"}}');
+
+        $qb = $this->qb();
+        $qb->table('mock_json_p2')->where('id', '=', $id)
+            ->update(['jsonCol' => $qb->jsonExpression()->set('jsonCol', ['profile', 'name'], 'New')]);
+
+        $data = $this->readJson($id);
+        $this->assertEquals('New', $data['profile']['name']);
+    }
+
+    /** @testdox [#28] JSON_ARRAY_APPEND via appendArray() appends to a live array. */
+    public function testAppendArray(): void
+    {
+        $id = $this->seed('{"list": [1, 2]}');
+
+        $qb = $this->qb();
+        $qb->table('mock_json_p2')->where('id', '=', $id)
+            ->update(['jsonCol' => $qb->jsonExpression()->appendArray('jsonCol', ['list'], 3)]);
+
+        $data = $this->readJson($id);
+        $this->assertEquals([1, 2, 3], $data['list']);
+    }
+
+    /** @testdox [#28] JSON_REMOVE via remove() drops a key in the live DB. */
+    public function testRemoveKey(): void
+    {
+        $id = $this->seed('{"keep": 1, "drop": 2}');
+
+        $qb = $this->qb();
+        $qb->table('mock_json_p2')->where('id', '=', $id)
+            ->update(['jsonCol' => $qb->jsonExpression()->remove('jsonCol', ['drop'])]);
+
+        $data = $this->readJson($id);
+        $this->assertArrayHasKey('keep', $data);
+        $this->assertArrayNotHasKey('drop', $data);
+    }
+
+    /** @testdox [#28] JSON_MERGE_PATCH via mergePatch() merges a document in the live DB. */
+    public function testMergePatch(): void
+    {
+        $id = $this->seed('{"a": 1, "b": 2}');
+
+        $qb = $this->qb();
+        $qb->table('mock_json_p2')->where('id', '=', $id)
+            ->update(['jsonCol' => $qb->jsonExpression()->mergePatch('jsonCol', ['b' => 20, 'c' => 30])]);
+
+        $data = $this->readJson($id);
+        $this->assertEquals(['a' => 1, 'b' => 20, 'c' => 30], $data);
+    }
+
+    /** @testdox [#28] orderByJson() with a cast sorts JSON values numerically in the live DB. */
+    public function testOrderByJsonCastNumeric(): void
+    {
+        $this->seed('{"age": "9"}');
+        $this->seed('{"age": "10"}');
+        $this->seed('{"age": "2"}');
+
+        // Cast to UNSIGNED so 10 sorts after 9 (numeric, not lexicographic).
+        $rows = $this->qb()->table('mock_json_p2')
+            ->select('jsonCol')
+            ->orderByJson('jsonCol', 'age', 'ASC', 'UNSIGNED')
+            ->get();
+
+        $ages = array_map(static function ($row): int {
+            return (int) \json_decode($row->jsonCol, true)['age'];
+        }, $rows);
+
+        $this->assertEquals([2, 9, 10], $ages);
+    }
+}

--- a/tests/QueryBuilderHandler/TestStatementObjects.php
+++ b/tests/QueryBuilderHandler/TestStatementObjects.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests that query statements are now value objects while remaining
+ * backwards-compatible with the previous associative-array shape (#56).
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\QueryBuilderHandler;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\QueryBuilder\QueryBuilderHandler;
+use Pixie\QueryBuilder\Statement\Statement;
+use Pixie\QueryBuilder\Statement\JoinStatement;
+use Pixie\QueryBuilder\Statement\OrderByStatement;
+use Pixie\QueryBuilder\Statement\CriteriaStatement;
+
+class TestStatementObjects extends WP_UnitTestCase
+{
+    private function qb(): QueryBuilderHandler
+    {
+        return new QueryBuilderHandler(new Connection(new Logable_WPDB(), []));
+    }
+
+    /** @testdox [#56] A where statement is a CriteriaStatement object. */
+    public function testWhereIsObject(): void
+    {
+        $statements = $this->qb()->table('foo')->where('a', '=', 1)->getStatements();
+
+        $this->assertInstanceOf(CriteriaStatement::class, $statements['wheres'][0]);
+        $this->assertInstanceOf(Statement::class, $statements['wheres'][0]);
+    }
+
+    /** @testdox [#56][BC] A where statement is still readable via array access. */
+    public function testWhereArrayAccessCompatible(): void
+    {
+        $where = $this->qb()->table('foo')->where('a', '=', 1)->getStatements()['wheres'][0];
+
+        $this->assertEquals('a', $where['key']);
+        $this->assertEquals('=', $where['operator']);
+        $this->assertEquals(1, $where['value']);
+        $this->assertEquals('AND', $where['joiner']);
+        $this->assertTrue(isset($where['key']));
+    }
+
+    /** @testdox [#56] A where statement exposes typed getters and toArray(). */
+    public function testWhereGettersAndToArray(): void
+    {
+        $where = $this->qb()->table('foo')->where('a', '=', 1)->getStatements()['wheres'][0];
+
+        $this->assertEquals('a', $where->getKey());
+        $this->assertEquals('=', $where->getOperator());
+        $this->assertEquals(1, $where->getValue());
+        $this->assertEquals('AND', $where->getJoiner());
+        $this->assertSame(
+            ['key' => 'a', 'operator' => '=', 'value' => 1, 'joiner' => 'AND'],
+            $where->toArray()
+        );
+    }
+
+    /** @testdox [#56] A having statement is a CriteriaStatement object. */
+    public function testHavingIsObject(): void
+    {
+        $statements = $this->qb()->table('foo')
+            ->groupBy('a')->having('a', '>', 1)->getStatements();
+
+        $this->assertInstanceOf(CriteriaStatement::class, $statements['havings'][0]);
+        $this->assertEquals('a', $statements['havings'][0]['key']);
+    }
+
+    /** @testdox [#56] An order by statement is an OrderByStatement object. */
+    public function testOrderByIsObject(): void
+    {
+        $statements = $this->qb()->table('foo')->orderBy('a', 'DESC')->getStatements();
+
+        $this->assertInstanceOf(OrderByStatement::class, $statements['orderBys'][0]);
+        $this->assertEquals('a', $statements['orderBys'][0]['field']);
+        $this->assertEquals('DESC', $statements['orderBys'][0]->getType());
+    }
+
+    /** @testdox [#56] A join statement is a JoinStatement object. */
+    public function testJoinIsObject(): void
+    {
+        $statements = $this->qb()->table('foo')
+            ->join('bar', 'foo.id', '=', 'bar.foo_id')->getStatements();
+
+        $this->assertInstanceOf(JoinStatement::class, $statements['joins'][0]);
+        $this->assertEquals('inner', $statements['joins'][0]['type']);
+        $this->assertEquals('bar', $statements['joins'][0]->getTable());
+    }
+
+    /** @testdox [#56] A statement object is iterable yielding its fields. */
+    public function testStatementIsIterable(): void
+    {
+        $where = $this->qb()->table('foo')->where('a', '=', 1)->getStatements()['wheres'][0];
+
+        $collected = [];
+        foreach ($where as $field => $value) {
+            $collected[$field] = $value;
+        }
+
+        $this->assertEquals(['key' => 'a', 'operator' => '=', 'value' => 1, 'joiner' => 'AND'], $collected);
+    }
+
+    /** @testdox [#56][BC] Generated SQL is unchanged by the statement-object conversion. */
+    public function testGeneratedSqlUnchanged(): void
+    {
+        $sql = $this->qb()->table('foo')
+            ->join('bar', 'foo.id', '=', 'bar.foo_id')
+            ->where('foo.a', '=', 1)
+            ->groupBy('foo.b')
+            ->having('foo.a', '>', 0)
+            ->orderBy('foo.b', 'DESC')
+            ->getQuery()->getRawSql();
+
+        $this->assertEquals(
+            'SELECT * FROM foo INNER JOIN bar ON foo.id = bar.foo_id WHERE foo.a = 1 GROUP BY foo.b HAVING foo.a > 0 ORDER BY foo.b DESC',
+            $sql
+        );
+    }
+}

--- a/tests/QueryBuilderHandler/TestTableAlias.php
+++ b/tests/QueryBuilderHandler/TestTableAlias.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SQL generation tests for table aliasing via the ['table' => 'alias'] syntax (#27).
+ *
+ * Covers both (a) the table used for query selection (table()/from()) and
+ * (b) the table used in a join condition, with and without a table prefix.
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\QueryBuilderHandler;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\QueryBuilder\QueryBuilderHandler;
+
+class TestTableAlias extends WP_UnitTestCase
+{
+    private function qb(?string $prefix = null): QueryBuilderHandler
+    {
+        $config = $prefix ? [Connection::PREFIX => $prefix] : [];
+        return new QueryBuilderHandler(new Connection(new Logable_WPDB(), $config));
+    }
+
+    /** @testdox [#27] A selection table can be aliased with from(['table' => 'alias']). */
+    public function testFromTableAlias(): void
+    {
+        $sql = $this->qb()->from(['foo' => 'f'])->getQuery()->getSql();
+        $this->assertEquals('SELECT * FROM foo AS f', $sql);
+    }
+
+    /** @testdox [#27] A selection table can be aliased with table(['table' => 'alias']). */
+    public function testSelectTableAlias(): void
+    {
+        $sql = $this->qb()->table(['foo' => 'f'])->getQuery()->getSql();
+        $this->assertEquals('SELECT * FROM foo AS f', $sql);
+    }
+
+    /** @testdox [#27] The table prefix is applied to the table, not the alias. */
+    public function testSelectTableAliasWithPrefix(): void
+    {
+        $sql = $this->qb('pr_')->table(['foo' => 'f'])->getQuery()->getSql();
+        $this->assertEquals('SELECT * FROM pr_foo AS f', $sql);
+    }
+
+    /** @testdox [#27] Aliased and plain tables can be mixed in a single selection. */
+    public function testMixedAliasedAndPlainTables(): void
+    {
+        $sql = $this->qb()->table('foo', ['bar' => 'b'])->getQuery()->getSql();
+        $this->assertEquals('SELECT * FROM foo, bar AS b', $sql);
+    }
+
+    /** @testdox [#27] A join table can be aliased with the ['table' => 'alias'] syntax. */
+    public function testJoinTableAliasAssociative(): void
+    {
+        $sql = $this->qb()
+            ->table('foo')
+            ->join(['bar' => 'b'], 'foo.id', '=', 'b.foo_id')
+            ->getQuery()->getSql();
+
+        $this->assertEquals('SELECT * FROM foo INNER JOIN bar AS b ON foo.id = b.foo_id', $sql);
+    }
+
+    /**
+     * @testdox [#27] The join table alias definition prefixes the table, not the alias label.
+     *
+     * Note: the value side of the ON condition (`b.foo_id`) is still run through
+     * the table prefixer, which cannot distinguish an alias from a real table —
+     * this is pre-existing condition-prefixing behaviour, independent of #27.
+     * The alias definition itself (`pr_bar AS b`) is what #27 covers.
+     */
+    public function testJoinTableAliasWithPrefix(): void
+    {
+        $sql = $this->qb('pr_')
+            ->table('foo')
+            ->join(['bar' => 'b'], 'foo.id', '=', 'b.foo_id')
+            ->getQuery()->getSql();
+
+        $this->assertEquals('SELECT * FROM pr_foo INNER JOIN pr_bar AS b ON pr_foo.id = pr_b.foo_id', $sql);
+    }
+
+    /** @testdox [#27][BC] The legacy indexed ['table', 'alias'] join syntax still works. */
+    public function testJoinTableAliasIndexedStillWorks(): void
+    {
+        $sql = $this->qb()
+            ->table('foo')
+            ->join(['bar', 'b'], 'foo.id', '=', 'b.foo_id')
+            ->getQuery()->getSql();
+
+        $this->assertEquals('SELECT * FROM foo INNER JOIN bar AS b ON foo.id = b.foo_id', $sql);
+    }
+}

--- a/tests/QueryBuilderHandler/TestThrowOnWpdbError.php
+++ b/tests/QueryBuilderHandler/TestThrowOnWpdbError.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Integration tests for the opt-in "throw on WPDB error" behaviour (#26).
+ *
+ * Verifies that, when a connection is configured with
+ * Connection::THROW_ON_ERROR, a WPDB error during execution raises a
+ * WpDbException, and that the default behaviour (flag off) is unchanged.
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\QueryBuilderHandler;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\WpDbException;
+use Pixie\QueryBuilder\QueryBuilderHandler;
+
+class TestThrowOnWpdbError extends WP_UnitTestCase
+{
+    /** @var \wpdb */
+    private $wpdb;
+
+    public function setUp(): void
+    {
+        global $wpdb;
+        $this->wpdb = clone $wpdb;
+        // The WP test bootstrap suppresses error output; ensure last_error is
+        // still captured (suppress_errors does not clear last_error).
+        $this->wpdb->suppress_errors(true);
+        parent::setUp();
+    }
+
+    /**
+     * Builds a query builder bound to a connection with the given config.
+     *
+     * @param array<string, mixed> $config
+     */
+    private function builder(array $config = []): QueryBuilderHandler
+    {
+        $connection = new Connection($this->wpdb, $config);
+        return new QueryBuilderHandler($connection);
+    }
+
+    /** @testdox [#26] With THROW_ON_ERROR enabled, a select against a missing table throws a WpDbException. */
+    public function testThrowsOnSelectError(): void
+    {
+        $builder = $this->builder([Connection::THROW_ON_ERROR => true]);
+
+        $this->expectException(WpDbException::class);
+
+        $builder->table('pixie_no_such_table_26')->get();
+    }
+
+    /** @testdox [#26] The thrown WpDbException is a Pixie Exception and carries the WPDB error message. */
+    public function testExceptionTypeAndMessage(): void
+    {
+        $builder = $this->builder([Connection::THROW_ON_ERROR => true]);
+
+        try {
+            $builder->table('pixie_no_such_table_26')->get();
+            $this->fail('Expected WpDbException was not thrown.');
+        } catch (WpDbException $e) {
+            $this->assertInstanceOf(\Pixie\Exception::class, $e);
+            $this->assertInstanceOf(\Exception::class, $e);
+            $this->assertNotEmpty($e->getMessage());
+            $this->assertStringContainsString($this->wpdb->last_error, $e->getMessage());
+        }
+    }
+
+    /** @testdox [#26][BC] Without the flag, a select against a missing table does NOT throw and returns null. */
+    public function testDoesNotThrowByDefault(): void
+    {
+        $builder = $this->builder();
+
+        $result = $builder->table('pixie_no_such_table_26')->get();
+
+        $this->assertEmpty($result);
+    }
+
+    /** @testdox [#26] With THROW_ON_ERROR enabled, an insert against a missing table throws a WpDbException. */
+    public function testThrowsOnInsertError(): void
+    {
+        $builder = $this->builder([Connection::THROW_ON_ERROR => true]);
+
+        $this->expectException(WpDbException::class);
+
+        $builder->table('pixie_no_such_table_26')->insert(['string' => 'a']);
+    }
+
+    /** @testdox [#26] When a query succeeds, no exception is thrown even with THROW_ON_ERROR enabled. */
+    public function testNoThrowOnSuccessfulQuery(): void
+    {
+        // mock_foo is created by the sibling integration suite; create defensively.
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        \dbDelta(
+            "CREATE TABLE mock_foo (
+             id mediumint(8) unsigned NOT NULL auto_increment,
+             string varchar(255) NULL,
+             number int NULL,
+             PRIMARY KEY  (id)
+            ) COLLATE {$this->wpdb->collate}"
+        );
+
+        $builder = $this->builder([Connection::THROW_ON_ERROR => true]);
+        $result  = $builder->table('mock_foo')->get();
+
+        // No exception; an empty table returns an empty result set.
+        $this->assertEmpty($result);
+    }
+}

--- a/tests/QueryBuilderHandler/TestWhenConditional.php
+++ b/tests/QueryBuilderHandler/TestWhenConditional.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SQL generation tests for the Eloquent-style when() conditional (#36).
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\QueryBuilderHandler;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\QueryBuilder\QueryBuilderHandler;
+
+class TestWhenConditional extends WP_UnitTestCase
+{
+    private function qb(): QueryBuilderHandler
+    {
+        return new QueryBuilderHandler(new Connection(new Logable_WPDB(), []));
+    }
+
+    /** @testdox [#36] when(true, ...) applies the true closure. */
+    public function testAppliesTrueBranchWhenTrue(): void
+    {
+        $sql = $this->qb()->table('foo')
+            ->when(true, function ($q): void {
+                $q->where('active', '=', 1);
+            })
+            ->getQuery()->getRawSql();
+
+        $this->assertEquals('SELECT * FROM foo WHERE active = 1', $sql);
+    }
+
+    /** @testdox [#36] when(false, ...) skips the true closure and leaves the query untouched. */
+    public function testSkipsTrueBranchWhenFalse(): void
+    {
+        $sql = $this->qb()->table('foo')
+            ->when(false, function ($q): void {
+                $q->where('active', '=', 1);
+            })
+            ->getQuery()->getSql();
+
+        $this->assertEquals('SELECT * FROM foo', $sql);
+    }
+
+    /** @testdox [#36] when(false, ..., $false) applies the optional false closure. */
+    public function testAppliesFalseBranchWhenFalse(): void
+    {
+        $sql = $this->qb()->table('foo')
+            ->when(
+                false,
+                function ($q): void {
+                    $q->where('active', '=', 1);
+                },
+                function ($q): void {
+                    $q->where('archived', '=', 1);
+                }
+            )
+            ->getQuery()->getRawSql();
+
+        $this->assertEquals('SELECT * FROM foo WHERE archived = 1', $sql);
+    }
+
+    /** @testdox [#36] when() returns the builder for fluent chaining when the closure returns nothing. */
+    public function testReturnsBuilderForChaining(): void
+    {
+        $builder = $this->qb()->table('foo');
+
+        $returned = $builder->when(true, function ($q): void {
+            $q->where('active', '=', 1);
+        });
+
+        $this->assertInstanceOf(QueryBuilderHandler::class, $returned);
+
+        // Chaining continues to work after when().
+        $sql = $returned->where('number', '>', 5)->getQuery()->getRawSql();
+        $this->assertEquals('SELECT * FROM foo WHERE active = 1 AND number > 5', $sql);
+    }
+
+    /** @testdox [#36] when() passes the query builder instance into the closure. */
+    public function testClosureReceivesBuilder(): void
+    {
+        $received = null;
+        $builder  = $this->qb()->table('foo');
+
+        $builder->when(true, function ($q) use (&$received): void {
+            $received = $q;
+        });
+
+        $this->assertSame($builder, $received);
+    }
+}

--- a/tests/Unit/TestConditionHandlers.php
+++ b/tests/Unit/TestConditionHandlers.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for the self-contained condition handlers extracted in #31.
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\Unit;
+
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\QueryBuilder\WPDBAdapter;
+use Pixie\QueryBuilder\QueryBuilderHandler;
+use Pixie\QueryBuilder\Handler\JoinConditionHandler;
+use Pixie\QueryBuilder\Handler\WhereConditionHandler;
+use Pixie\QueryBuilder\Handler\TableConditionHandler;
+use Pixie\QueryBuilder\Handler\SelectConditionHandler;
+
+class TestConditionHandlers extends WP_UnitTestCase
+{
+    private function adapter(): WPDBAdapter
+    {
+        return new WPDBAdapter(new Connection(new Logable_WPDB(), []));
+    }
+
+    private function qb(): QueryBuilderHandler
+    {
+        return new QueryBuilderHandler(new Connection(new Logable_WPDB(), []));
+    }
+
+    /** @testdox [#31] TableConditionHandler renders plain and aliased tables. */
+    public function testTableHandler(): void
+    {
+        $handler = new TableConditionHandler($this->adapter());
+
+        $this->assertEquals('foo, bar', $handler->build([0 => 'foo', 1 => 'bar']));
+        $this->assertEquals('users AS u', $handler->build(['users' => 'u']));
+    }
+
+    /** @testdox [#31] SelectConditionHandler renders plain and aliased fields. */
+    public function testSelectHandler(): void
+    {
+        $handler = new SelectConditionHandler($this->adapter());
+
+        $this->assertEquals('a, b', $handler->build([0 => 'a', 1 => 'b']));
+        $this->assertEquals('total AS t', $handler->build(['total' => 't']));
+    }
+
+    /** @testdox [#31] WhereConditionHandler builds a typed criteria fragment from real statements. */
+    public function testWhereHandler(): void
+    {
+        $statements = $this->qb()->table('foo')->where('a', '=', 1)->getStatements();
+
+        $handler = new WhereConditionHandler($this->adapter());
+        [$criteria, $bindings] = $handler->build($statements, 'wheres', 'WHERE');
+
+        $this->assertStringStartsWith('WHERE', $criteria);
+        $this->assertStringContainsString('a =', $criteria);
+        $this->assertEquals([1], $bindings);
+    }
+
+    /** @testdox [#31] WhereConditionHandler returns an empty fragment when the key is absent. */
+    public function testWhereHandlerEmpty(): void
+    {
+        $handler = new WhereConditionHandler($this->adapter());
+        [$criteria, $bindings] = $handler->build([], 'wheres', 'WHERE');
+
+        $this->assertEquals('', $criteria);
+        $this->assertEquals([], $bindings);
+    }
+
+    /** @testdox [#31] JoinConditionHandler builds a JOIN clause (incl. aliased tables) from real statements. */
+    public function testJoinHandler(): void
+    {
+        $statements = $this->qb()->table('foo')
+            ->join(['bar' => 'b'], 'foo.id', '=', 'b.foo_id')
+            ->getStatements();
+
+        $handler = new JoinConditionHandler($this->adapter());
+        $sql     = $handler->build($statements);
+
+        $this->assertEquals('INNER JOIN bar AS b ON foo.id = b.foo_id', $sql);
+    }
+
+    /** @testdox [#31] JoinConditionHandler returns an empty string when there are no joins. */
+    public function testJoinHandlerNoJoins(): void
+    {
+        $handler = new JoinConditionHandler($this->adapter());
+        $this->assertEquals('', $handler->build([]));
+    }
+
+    /** @testdox [#31][BC] End-to-end query generation is unchanged after the extraction. */
+    public function testEndToEndUnchanged(): void
+    {
+        $sql = $this->qb()->table('foo')
+            ->select(['foo.a', 'foo.b'])
+            ->join(['bar' => 'b'], 'foo.id', '=', 'b.foo_id')
+            ->where('foo.a', '=', 1)
+            ->getQuery()->getRawSql();
+
+        $this->assertEquals(
+            'SELECT foo.a, foo.b FROM foo INNER JOIN bar AS b ON foo.id = b.foo_id WHERE foo.a = 1',
+            $sql
+        );
+    }
+}

--- a/tests/Unit/TestConditionHandlers.php
+++ b/tests/Unit/TestConditionHandlers.php
@@ -94,6 +94,30 @@ class TestConditionHandlers extends WP_UnitTestCase
         $this->assertEquals('', $handler->build([]));
     }
 
+    /** @testdox [#31] JoinConditionHandler builds a JOIN with a plain (non-aliased) string table. */
+    public function testJoinHandlerPlainStringTable(): void
+    {
+        $statements = $this->qb()->table('foo')
+            ->join('bar', 'foo.id', '=', 'bar.foo_id')
+            ->getStatements();
+
+        $handler = new JoinConditionHandler($this->adapter());
+
+        $this->assertEquals('INNER JOIN bar ON foo.id = bar.foo_id', $handler->build($statements));
+    }
+
+    /** @testdox [#31] JoinConditionHandler builds a JOIN with a Raw table expression. */
+    public function testJoinHandlerRawTable(): void
+    {
+        $statements = $this->qb()->table('foo')
+            ->join(new \Pixie\QueryBuilder\Raw('bar'), 'foo.id', '=', 'bar.foo_id')
+            ->getStatements();
+
+        $handler = new JoinConditionHandler($this->adapter());
+
+        $this->assertEquals('INNER JOIN bar ON foo.id = bar.foo_id', $handler->build($statements));
+    }
+
     /** @testdox [#31][BC] End-to-end query generation is unchanged after the extraction. */
     public function testEndToEndUnchanged(): void
     {

--- a/tests/Unit/TestEventObject.php
+++ b/tests/Unit/TestEventObject.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for the object-based events introduced in #50: the Event value object,
+ * its lazy static constructors and EventHandler::register()/getRegisteredEvents().
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\Unit;
+
+use Pixie\Event;
+use WP_UnitTestCase;
+use Pixie\EventHandler;
+
+class TestEventObject extends WP_UnitTestCase
+{
+    /** @testdox [#50] An Event object exposes its name, table and action. */
+    public function testEventExposesProperties(): void
+    {
+        $action = function () {
+            return 'x';
+        };
+        $event = new Event(Event::BEFORE_SELECT, 'foo', $action);
+
+        $this->assertEquals(Event::BEFORE_SELECT, $event->getName());
+        $this->assertEquals('foo', $event->getTable());
+        $this->assertSame($action, $event->getAction());
+    }
+
+    /** @testdox [#50] A null table resolves to the :any sentinel. */
+    public function testNullTableBecomesAny(): void
+    {
+        $event = new Event(Event::AFTER_SELECT, null, function () {
+        });
+        $this->assertEquals(Event::ANY_TABLE, $event->getTable());
+        $this->assertEquals(':any', $event->getTable());
+    }
+
+    /** @testdox [#50] Event::on() is a lazy static constructor. */
+    public function testOnFactory(): void
+    {
+        $event = Event::on('custom-event', 'foo', function () {
+        });
+        $this->assertEquals('custom-event', $event->getName());
+        $this->assertEquals('foo', $event->getTable());
+    }
+
+    /**
+     * @testdox [#50] Each typed lazy static constructor maps to its event constant.
+     * @dataProvider typedConstructorProvider
+     */
+    public function testTypedConstructors(string $method, string $expectedName): void
+    {
+        $event = Event::{$method}('foo', function () {
+        });
+        $this->assertEquals($expectedName, $event->getName());
+        $this->assertEquals('foo', $event->getTable());
+    }
+
+    /** @return array<string, array{0:string,1:string}> */
+    public function typedConstructorProvider(): array
+    {
+        return [
+            'beforeSelect' => ['beforeSelect', Event::BEFORE_SELECT],
+            'afterSelect'  => ['afterSelect', Event::AFTER_SELECT],
+            'beforeInsert' => ['beforeInsert', Event::BEFORE_INSERT],
+            'afterInsert'  => ['afterInsert', Event::AFTER_INSERT],
+            'beforeUpdate' => ['beforeUpdate', Event::BEFORE_UPDATE],
+            'afterUpdate'  => ['afterUpdate', Event::AFTER_UPDATE],
+            'beforeDelete' => ['beforeDelete', Event::BEFORE_DELETE],
+            'afterDelete'  => ['afterDelete', Event::AFTER_DELETE],
+        ];
+    }
+
+    /** @testdox [#50] EventHandler::register() accepts an Event object. */
+    public function testRegisterEventObject(): void
+    {
+        $handler = new EventHandler();
+        $event   = Event::beforeSelect('foo', function () {
+            return 'fired';
+        });
+
+        $handler->register($event);
+
+        // Retrievable as a closure (BC) ...
+        $closure = $handler->getEvent(Event::BEFORE_SELECT, 'foo');
+        $this->assertIsCallable($closure);
+        $this->assertEquals('fired', $closure());
+
+        // ... and as the Event object via the new accessor.
+        $registered = $handler->getRegisteredEvents();
+        $this->assertInstanceOf(Event::class, $registered['foo'][Event::BEFORE_SELECT]);
+        $this->assertSame($event, $registered['foo'][Event::BEFORE_SELECT]);
+    }
+
+    /** @testdox [#50][BC] registerEvent() still works and stores an Event internally. */
+    public function testRegisterEventLegacyStillWorks(): void
+    {
+        $handler = new EventHandler();
+        $handler->registerEvent(Event::AFTER_DELETE, 'bar', function () {
+            return 1;
+        });
+
+        $registered = $handler->getRegisteredEvents();
+        $this->assertInstanceOf(Event::class, $registered['bar'][Event::AFTER_DELETE]);
+        $this->assertEquals(1, $handler->getEvent(Event::AFTER_DELETE, 'bar')());
+    }
+}

--- a/tests/Unit/TestHydrator.php
+++ b/tests/Unit/TestHydrator.php
@@ -30,9 +30,9 @@ class TestHydrator extends WP_UnitTestCase
         $model = $hydrator->from(['foo' => 'a', 'bar' => 'b']);
 
         $this->assertInstanceOf(ModelWithUnderscoreSetters::class, $model);
-        $this->assertObjectHasAttribute('foo', $model);
+        $this->assertObjectHasProperty('foo', $model);
         $this->assertEquals('a', $model->foo);
-        $this->assertObjectHasAttribute('bar', $model);
+        $this->assertObjectHasProperty('bar', $model);
         $this->assertEquals('b', $model->bar);
     }
 
@@ -43,9 +43,9 @@ class TestHydrator extends WP_UnitTestCase
         $model = $hydrator->from((object)['foo' => 'a', 'bar' => 'b']);
 
         $this->assertInstanceOf(ModelWithUnderscoreSetters::class, $model);
-        $this->assertObjectHasAttribute('foo', $model);
+        $this->assertObjectHasProperty('foo', $model);
         $this->assertEquals('a', $model->foo);
-        $this->assertObjectHasAttribute('bar', $model);
+        $this->assertObjectHasProperty('bar', $model);
         $this->assertEquals('b', $model->bar);
     }
 
@@ -56,9 +56,9 @@ class TestHydrator extends WP_UnitTestCase
         $model = $hydrator->from(['foo' => 'a', 'bar' => 'b']);
 
         $this->assertInstanceOf(ModelWithSetters::class, $model);
-        $this->assertObjectHasAttribute('foo', $model);
+        $this->assertObjectHasProperty('foo', $model);
         $this->assertEquals('a', $model->foo);
-        $this->assertObjectHasAttribute('bar', $model);
+        $this->assertObjectHasProperty('bar', $model);
         $this->assertEquals('b', $model->bar);
     }
 
@@ -69,9 +69,9 @@ class TestHydrator extends WP_UnitTestCase
         $model = $hydrator->from((object)['foo' => 'a', 'bar' => 'b']);
 
         $this->assertInstanceOf(ModelWithSetters::class, $model);
-        $this->assertObjectHasAttribute('foo', $model);
+        $this->assertObjectHasProperty('foo', $model);
         $this->assertEquals('a', $model->foo);
-        $this->assertObjectHasAttribute('bar', $model);
+        $this->assertObjectHasProperty('bar', $model);
         $this->assertEquals('b', $model->bar);
     }
 
@@ -82,9 +82,9 @@ class TestHydrator extends WP_UnitTestCase
         $model = $hydrator->from(['foo' => 'a', 'bar' => 'b']);
 
         $this->assertInstanceOf(ModelWithNoSetters::class, $model);
-        $this->assertObjectHasAttribute('foo', $model);
+        $this->assertObjectHasProperty('foo', $model);
         $this->assertEquals('a', $model->foo);
-        $this->assertObjectHasAttribute('bar', $model);
+        $this->assertObjectHasProperty('bar', $model);
         $this->assertEquals('b', $model->bar);
     }
 
@@ -95,9 +95,9 @@ class TestHydrator extends WP_UnitTestCase
         $model = $hydrator->from((object)['foo' => 'a', 'bar' => 'b']);
 
         $this->assertInstanceOf(ModelWithNoSetters::class, $model);
-        $this->assertObjectHasAttribute('foo', $model);
+        $this->assertObjectHasProperty('foo', $model);
         $this->assertEquals('a', $model->foo);
-        $this->assertObjectHasAttribute('bar', $model);
+        $this->assertObjectHasProperty('bar', $model);
         $this->assertEquals('b', $model->bar);
     }
 

--- a/tests/Unit/TestSanitizer.php
+++ b/tests/Unit/TestSanitizer.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unit tests for the self-contained Sanitizer relocated out of WPDBAdapter (#48).
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\Unit;
+
+use Closure;
+use WP_UnitTestCase;
+use Pixie\QueryBuilder\Raw;
+use Pixie\QueryBuilder\Sanitizer;
+
+class TestSanitizer extends WP_UnitTestCase
+{
+    /** @testdox [#48] With no sanitizer character a plain field is returned untouched. */
+    public function testPlainFieldWithoutSanitizer(): void
+    {
+        $sanitizer = new Sanitizer('');
+        $this->assertEquals('id', $sanitizer->wrap('id'));
+    }
+
+    /** @testdox [#48] A field is wrapped with the configured sanitizer character. */
+    public function testWrapsFieldWithSanitizer(): void
+    {
+        $sanitizer = new Sanitizer('`');
+        $this->assertEquals('`id`', $sanitizer->wrap('id'));
+    }
+
+    /** @testdox [#48] A table.field value is wrapped per segment. */
+    public function testWrapsEachDotSegment(): void
+    {
+        $sanitizer = new Sanitizer('`');
+        $this->assertEquals('`my_table`.`id`', $sanitizer->wrap('my_table.id'));
+    }
+
+    /** @testdox [#48] A "*" segment is never wrapped. */
+    public function testStarIsNotWrapped(): void
+    {
+        $sanitizer = new Sanitizer('`');
+        $this->assertEquals('*', $sanitizer->wrap('*'));
+        $this->assertEquals('`my_table`.*', $sanitizer->wrap('my_table.*'));
+    }
+
+    /** @testdox [#48] A Closure value is returned unchanged for later resolution. */
+    public function testClosureReturnedAsIs(): void
+    {
+        $sanitizer = new Sanitizer('`');
+        $closure   = function (): void {
+        };
+        $this->assertSame($closure, $sanitizer->wrap($closure));
+    }
+
+    /** @testdox [#48] A Raw value is stringified through the provided raw parser. */
+    public function testRawValueUsesProvidedParser(): void
+    {
+        $sanitizer = new Sanitizer('`');
+        $raw       = new Raw('NOW()');
+
+        $result = $sanitizer->wrap($raw, function (Raw $r): string {
+            return 'PARSED:' . (string) $r;
+        });
+
+        $this->assertEquals('PARSED:NOW()', $result);
+    }
+
+    /** @testdox [#48] A Raw value falls back to its __toString when no parser is given. */
+    public function testRawValueFallsBackToToString(): void
+    {
+        $sanitizer = new Sanitizer('`');
+        $raw       = new Raw('NOW()');
+
+        $this->assertEquals('NOW()', $sanitizer->wrap($raw));
+    }
+
+    /** @testdox [#48] The configured sanitizer character is exposed via getSanitizer(). */
+    public function testGetSanitizer(): void
+    {
+        $this->assertEquals('`', (new Sanitizer('`'))->getSanitizer());
+        $this->assertEquals('', (new Sanitizer())->getSanitizer());
+    }
+}

--- a/tests/Unit/TestValueObjectInternals.php
+++ b/tests/Unit/TestValueObjectInternals.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Coverage for the statement value objects' full ArrayAccess surface and
+ * typed accessors (#56), and the WpDbException factory fallbacks (#26).
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\Unit;
+
+use WP_UnitTestCase;
+use Pixie\WpDbException;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\QueryBuilder\Statement\JoinStatement;
+use Pixie\QueryBuilder\Statement\OrderByStatement;
+use Pixie\QueryBuilder\Statement\CriteriaStatement;
+
+class TestValueObjectInternals extends WP_UnitTestCase
+{
+    /** @testdox [#56] A statement supports ArrayAccess writes via a keyed offset. */
+    public function testOffsetSetKeyed(): void
+    {
+        $statement = new CriteriaStatement('a', '=', 1, 'AND');
+        $statement['operator'] = '!=';
+
+        $this->assertEquals('!=', $statement['operator']);
+        $this->assertTrue(isset($statement['operator']));
+    }
+
+    /** @testdox [#56] A statement supports ArrayAccess append with a null offset. */
+    public function testOffsetSetAppend(): void
+    {
+        $statement = new CriteriaStatement('a', '=', 1, 'AND');
+        $statement[] = 'appended';
+
+        $this->assertContains('appended', $statement->toArray());
+    }
+
+    /** @testdox [#56] A statement supports ArrayAccess unset. */
+    public function testOffsetUnset(): void
+    {
+        $statement = new CriteriaStatement('a', '=', 1, 'AND');
+        unset($statement['value']);
+
+        $this->assertFalse(isset($statement['value']));
+        $this->assertArrayNotHasKey('value', $statement->toArray());
+    }
+
+    /** @testdox [#56] JoinStatement exposes typed getType()/getTable()/getJoinBuilder(). */
+    public function testJoinStatementGetters(): void
+    {
+        $builder   = new \stdClass();
+        $statement = new JoinStatement('left', 'comments', $builder);
+
+        $this->assertEquals('left', $statement->getType());
+        $this->assertEquals('comments', $statement->getTable());
+        $this->assertSame($builder, $statement->getJoinBuilder());
+    }
+
+    /** @testdox [#56] OrderByStatement exposes typed getField()/getType(). */
+    public function testOrderByStatementGetters(): void
+    {
+        $statement = new OrderByStatement('created_at', 'DESC');
+
+        $this->assertEquals('created_at', $statement->getField());
+        $this->assertEquals('DESC', $statement->getType());
+    }
+
+    /** @testdox [#26] WpDbException::fromWpdb() falls back to a default message when last_error is empty. */
+    public function testWpDbExceptionUnknownError(): void
+    {
+        $wpdb = new Logable_WPDB();
+        $wpdb->last_error = '';
+
+        $exception = WpDbException::fromWpdb($wpdb);
+
+        $this->assertEquals('Unknown WPDB error', $exception->getMessage());
+    }
+
+    /** @testdox [#26] WpDbException::fromWpdb() appends the SQL context when provided. */
+    public function testWpDbExceptionWithSql(): void
+    {
+        $wpdb = new Logable_WPDB();
+        $wpdb->last_error = 'Table missing';
+
+        $exception = WpDbException::fromWpdb($wpdb, 'SELECT * FROM nope');
+
+        $this->assertStringContainsString('Table missing', $exception->getMessage());
+        $this->assertStringContainsString('[SQL: SELECT * FROM nope]', $exception->getMessage());
+    }
+}

--- a/tests/Unit/TestWrapSanitizerBC.php
+++ b/tests/Unit/TestWrapSanitizerBC.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Backwards-compatibility tests for the public WPDBAdapter::wrapSanitizer()
+ * surface after the sanitiser was relocated into the Sanitizer class (#48).
+ *
+ * @since 0.2.0
+ * @author Glynn Quelch <glynn.quelch@gmail.com>
+ */
+
+namespace Pixie\Tests\Unit;
+
+use Closure;
+use WP_UnitTestCase;
+use Pixie\Connection;
+use Pixie\QueryBuilder\Raw;
+use Pixie\Tests\Logable_WPDB;
+use Pixie\QueryBuilder\WPDBAdapter;
+
+class TestWrapSanitizerBC extends WP_UnitTestCase
+{
+    private function getAdapter(): WPDBAdapter
+    {
+        return new WPDBAdapter(new Connection(new Logable_WPDB(), []));
+    }
+
+    /** @testdox [#48][BC] wrapSanitizer() is still public and handles plain fields. */
+    public function testWrapSanitizerHandlesPlainField(): void
+    {
+        $adapter = $this->getAdapter();
+        // Default adapter sanitizer is empty, so the value is returned untouched.
+        $this->assertEquals('my_table.id', $adapter->wrapSanitizer('my_table.id'));
+    }
+
+    /** @testdox [#48][BC] wrapSanitizer() leaves a "*" untouched. */
+    public function testWrapSanitizerKeepsStar(): void
+    {
+        $this->assertEquals('*', $this->getAdapter()->wrapSanitizer('*'));
+    }
+
+    /** @testdox [#48][BC] wrapSanitizer() parses a Raw value to a string. */
+    public function testWrapSanitizerParsesRaw(): void
+    {
+        $result = $this->getAdapter()->wrapSanitizer(new Raw('COUNT(*)'));
+        $this->assertEquals('COUNT(*)', $result);
+    }
+
+    /** @testdox [#48][BC] wrapSanitizer() returns a Closure unchanged. */
+    public function testWrapSanitizerReturnsClosure(): void
+    {
+        $closure = function (): void {
+        };
+        $this->assertSame($closure, $this->getAdapter()->wrapSanitizer($closure));
+    }
+}

--- a/tests/wp-config.php
+++ b/tests/wp-config.php
@@ -75,3 +75,15 @@ define( 'WP_TESTS_TITLE', 'Test Blog' );
 define( 'WP_PHP_BINARY', 'php' );
 
 define( 'WPLANG', '' );
+
+// Custom error handler to suppress known WP 6.8 notice about wp_is_block_theme being called too early.
+// @see https://core.trac.wordpress.org/ticket/63086
+set_error_handler(
+	function ( $errno, $errstr ) {
+		if ( $errno === E_USER_NOTICE && strpos( $errstr, 'wp_is_block_theme' ) !== false ) {
+			return true;
+		}
+		return false;
+	},
+	E_USER_NOTICE
+);


### PR DESCRIPTION
No breaking API changes. Full WP PHPUnit suite green; phpstan -l8 clean; php-cs-fixer @PSR12 clean.

- #26 Opt-in throw on WPDB error (Connection::THROW_ON_ERROR + WpDbException)
- #27 Table aliases via ['table' => 'alias'] for selection and joins
- #28 JSON Support Phase 2 (portable JSON_* modification expressions + orderByJson cast)
- #31 Uncouple QueryBuilder into self-contained condition handlers
- #36 Eloquent-style when(bool, Closure, ?Closure)
- #48 Relocate sanitiser into a Sanitizer class (wrapSanitizer kept for BC)
- #50 Object-based events (Event value object + lazy static constructors)
- #56 Statements as value objects (ArrayAccess; getStatements() shape unchanged)
- #70-74 Composer/toolchain alignment: WP 6.9, PHP floor 8.0, PHPUnit ^8||^9, PHPStan ^2

CI reworked into per-WP-version workflows (6.6-6.9 x PHP 8.0-8.4 x MySQL/MariaDB). (#55 complex example + visual page live in the consuming pixie-harness plugin.)